### PR TITLE
move project menu to the "add layer" menu

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -326,7 +326,7 @@ class menu_from_project:
 
     def addMenu(self, name, filename, domdoc):
         # main project menu
-        menuBar = self.iface.editMenu().parentWidget()
+        menuBar = self.iface.addLayerMenu()
         projectMenu = QMenu('&'+name, menuBar)
 
         projectMenu.setToolTipsVisible(self.optionTooltip)
@@ -379,7 +379,7 @@ class menu_from_project:
         return (doc, project_path)
 
     def initMenus(self):
-        menuBar = self.iface.editMenu().parentWidget()
+        menuBar = self.iface.addLayerMenu()
         for action in self.menubarActions:
             menuBar.removeAction(action)
             del action
@@ -417,7 +417,7 @@ class menu_from_project:
         self.initMenus()
 
     def unload(self):
-        menuBar = self.iface.editMenu().parentWidget()
+        menuBar = self.iface.addLayerMenu()
         for action in self.menubarActions:
             menuBar.removeAction(action)
 


### PR DESCRIPTION
do not merge this one

I don't want to break the existing location of the menu bar.

What do you think about this location of the menu?
![move_menu_to_layers](https://user-images.githubusercontent.com/1609292/51793724-7cdcbf80-219b-11e9-888f-9ae68a2c4f91.png)

It makes more sense to me.
I'm fine of course to add an option in the settings about the location. Should we do this per project? Or a general project?