### PR TITLE
Add support for "trusted project" option

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -137,6 +137,24 @@ def project_title(doc):
     return None
 
 
+def project_trusted(doc):
+    """Return if the project is trusted.
+
+    :param doc: The QGIS project as XML document. Default to None.
+    :type doc: QDomDocument
+
+    :return: True of False.
+    :rtype: bool
+    """
+    tags = doc.elementsByTagName('qgis')
+    if tags.count():
+        node = tags.at(0)
+        trust_node = node.namedItem('trust')
+        return trust_node.toElement().attribute("active") == "1"
+
+    return False
+
+
 class MenuFromProject:
 
     def __init__(self, iface):
@@ -677,6 +695,7 @@ class MenuFromProject:
 
                 # is project in relative path ?
                 absolute = isAbsolute(doc)
+                trusted = project_trusted(doc)
 
                 node = getFirstChildByTagNameValue(doc.documentElement(), "maplayer", "id",
                                                    layerId)
@@ -725,6 +744,7 @@ class MenuFromProject:
                         else:
                             theLayer = QgsVectorLayer()
 
+                        theLayer.setReadExtentFromXml(trusted)
                         theLayer.readLayerXml(node.toElement(), QgsReadWriteContext())
 
                         # Special process if the plugin "DB Style Manager" is installed


### PR DESCRIPTION
On QGIS, in the project properties, data source section, there is an option to say if the project is "trusted" which means that the provider will not try to get the metadata from the database, but from the XML layer properties.

It is very useful for me for loading layers that are database views (no statistics on view therefore the provider launches time consuming requests like `st_extent` for example with Postgresql).

As a result here is an updated version of `menu_from_project` to support this option when loading layers.

Tested on QGIS 3.4.13 - Windows 10.