### PR TITLE
Fix raster layer error with "trust project" option

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -743,8 +743,8 @@ class MenuFromProject:
                             theLayer = QgsRasterLayer()
                         else:
                             theLayer = QgsVectorLayer()
+                            theLayer.setReadExtentFromXml(trusted)
 
-                        theLayer.setReadExtentFromXml(trusted)
                         theLayer.readLayerXml(node.toElement(), QgsReadWriteContext())
 
                         # Special process if the plugin "DB Style Manager" is installed


### PR DESCRIPTION
Sorry for the late fix 👎 
Can't read extent from xml on raster layer type, so I moved the method to be used only on vector layers.