### PR TITLE
Use qgis-plugin-ci to push to QGIS plugins repo...

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,19 +56,10 @@ jobs:
         release_name: ${{ github.ref }}
         body_path: release.md
 
-    - name: upload plugin artifact
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ${{ env.PROJECT_FOLDER }}.${{steps.get-myversion.outputs.myversion}}.zip
-        asset_name: ${{ env.PROJECT_FOLDER }}-${{steps.get-myversion.outputs.myversion}}.zip
-        asset_content_type: application/zip
-
-    # - name: Deploy plugin
-    #   run: >-
-    #     qgis-plugin-ci
-    #     release ${GITHUB_REF/refs\/tags\//}
-    #     --github-token ${{ secrets.BOT_HUB_TOKEN }}
-    #     --transifex-token ${{ secrets.TRANSIFEX_TOKEN }}
+    - name: Deploy plugin to QGIS official repository and as release asset
+      run: >-
+        qgis-plugin-ci
+        release ${GITHUB_REF/refs\/tags\//}
+        --github-token ${{ secrets.GITHUB_TOKEN }}
+        --osgeo-username ${{ secrets.OSGEO_USER }}
+        --osgeo-password ${{ secrets.OSGEO_PASSWORD }}


### PR DESCRIPTION
...and also as GH release asset

To make it possible, the repository owner @xcaeag must enter its OSGeo credentials (used as authentication ref in QGIS official repository) as actions secrets:

https://github.com/xcaeag/MenuFromProject-Qgis-Plugin/settings/secrets/actions

![image](https://user-images.githubusercontent.com/1596222/119787194-42050680-bed1-11eb-83d5-e3611781aea4.png)

See: https://opengisch.github.io/qgis-plugin-ci/usage/ci_github.html

HS Recomendation: the "v" in tags is not really semver compliant and usually add confusion/complexity in automatic workflows (requiring to cut out the v, etc.)