### PR TITLE
Use QgsProject to load needed informations for menu creation

### DIFF
--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -1,0 +1,174 @@
+# standard
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+# PyQGIS
+from qgis.core import QgsLayerTreeNode, QgsMapLayerType, QgsProject, QgsWkbTypes
+
+
+@dataclass
+class MenuLayerConfig:
+    """Class to store configuration for layer menu creation"""
+
+    name: str
+    layer_id: str
+    filename: str
+    visible: bool
+    expanded: bool
+    embedded: str
+    is_spatial: bool
+    layer_type: QgsMapLayerType
+    metadata_abstract: str
+    metadata_title: str
+    abstract: str
+    title: str
+    geometry_type: Optional[QgsWkbTypes.GeometryType] = None
+
+
+@dataclass
+class MenuGroupConfig:
+    """Class to store configuration for group menu creation"""
+
+    name: str
+    filename: str
+    childs: List[Any]  # List of Union[MenuLayerConfig,MenuGroupConfig]
+    embedded: bool
+
+
+@dataclass
+class MenuProjectConfig:
+    """Class to store configuration for project menu creation"""
+
+    filename: str
+    uri: str
+    root_group: MenuGroupConfig
+
+
+def get_embedded_project_from_layer_tree(
+    layer_tree: QgsLayerTreeNode, project: QgsProject
+) -> str:
+    """Get embedded project path from layer tree and his parent
+
+    :param layer_tree: layer tree to inspect
+    :type layer_tree: QgsLayerTreeNode
+    :param project: project where layer tree is used
+    :type project: QgsProject
+    :return: path to embedded project
+    :rtype: str
+    """
+    filename = project.readPath(layer_tree.customProperty("embedded_project"))
+    if filename == "" and layer_tree.parent():
+        return get_embedded_project_from_layer_tree(
+            layer_tree=layer_tree.parent(), project=project
+        )
+    return filename
+
+
+def read_embedded_properties(
+    layer_tree: QgsLayerTreeNode, project: QgsProject
+) -> Tuple[bool, str]:
+    """Read embedded properties from a QgsLayerTreeNode in a QgsProject
+
+    :param layer_tree: layer tree to inspect
+    :type layer_tree: QgsLayerTreeNode
+    :param project: project where layer tree is used
+    :type project: QgsProject
+    :return: Boolean indicating if the layer tree is embedded and the filename of the project used
+    :rtype: Tuple[bool, str]
+    """
+    # Embedded property is not read if QgsProject.FlagDontResolveLayers flag is use when reading QgsProject
+    if layer_tree.customProperty("embedded"):
+        embedded = True
+        filename = get_embedded_project_from_layer_tree(
+            layer_tree=layer_tree, project=project
+        )
+    else:
+        embedded = False
+        filename = project.absoluteFilePath()
+    return embedded, filename
+
+
+def get_layer_menu_config(
+    layer_tree: QgsLayerTreeNode, project: QgsProject
+) -> MenuLayerConfig:
+    """Get layer menu configuration from a QgsLayerTreeNode in a QgsProject
+
+    :param layer_tree: layer tree to inspect
+    :type layer_tree: QgsLayerTreeNode
+    :param project: project where layer tree is used
+    :type project: QgsProject
+    :return: Layer menu configuration
+    :rtype: MenuLayerConfig
+    """
+
+    embedded, filename = read_embedded_properties(
+        layer_tree=layer_tree, project=project
+    )
+
+    # Get project map layer
+    layer = project.mapLayer(layer_tree.layerId())
+
+    return MenuLayerConfig(
+        name=layer_tree.name(),
+        layer_id=layer_tree.layerId(),
+        filename=filename,
+        visible=layer_tree.itemVisibilityChecked(),
+        expanded=layer_tree.isExpanded(),
+        embedded=embedded,
+        layer_type=layer.type(),
+        metadata_abstract=layer.metadata().abstract(),
+        metadata_title=layer.metadata().title(),
+        abstract=layer.abstract(),
+        is_spatial=layer.isSpatial(),
+        title=layer.title(),
+        geometry_type=(
+            layer.geometryType()
+            if layer.type() == QgsMapLayerType.VectorLayer
+            else None
+        ),
+    )
+
+
+def get_group_menu_config(
+    layer_tree: QgsLayerTreeNode, project: QgsProject
+) -> MenuGroupConfig:
+    """Get group menu configuration from a QgsLayerTreeNode in a QgsProject
+
+    :param layer_tree: layer tree to inspect
+    :type layer_tree: QgsLayerTreeNode
+    :param project: project where layer tree is used
+    :type project: QgsProject
+    :return: Group menu configuration
+    :rtype: MenuGroupConfig
+    """
+    embedded, filename = read_embedded_properties(
+        layer_tree=layer_tree, project=project
+    )
+
+    childs = []
+
+    for child in layer_tree.children():
+        if child.nodeType() == QgsLayerTreeNode.NodeGroup:
+            childs.append(get_group_menu_config(child, project))
+        elif child.nodeType() == QgsLayerTreeNode.NodeLayer:
+            childs.append(get_layer_menu_config(child, project))
+    return MenuGroupConfig(
+        name=layer_tree.name(), embedded=embedded, filename=filename, childs=childs
+    )
+
+
+def get_project_menu_config(qgs_project: QgsProject, uri: str) -> MenuProjectConfig:
+    """Get project menu configuration from a QgsProject
+
+    :param qgs_project: project
+    :type qgs_project: QgsProject
+    :param uri: initial uri of project (can be from local file / http / postgres)
+    :type uri: str
+    :return: Project menu configuration
+    :rtype: MenuProjectConfig
+    """
+    return MenuProjectConfig(
+        filename=qgs_project.absoluteFilePath(),
+        uri=uri,
+        root_group=get_group_menu_config(qgs_project.layerTreeRoot(), qgs_project),
+    )

--- a/menu_from_project/logic/qgs_manager.py
+++ b/menu_from_project/logic/qgs_manager.py
@@ -59,24 +59,6 @@ def is_absolute(doc: QtXml.QDomDocument) -> bool:
     return absolute
 
 
-def get_project_title(doc: QtXml.QDomDocument) -> str:
-    """Return the project title defined in the XML document.
-
-    :param doc: The QGIS project as XML document. Default to None.
-    :type doc: QDomDocument
-
-    :return: The title or None.
-    :rtype: string
-    """
-    tags = doc.elementsByTagName("qgis")
-    if tags.count():
-        node = tags.at(0)
-        title_node = node.namedItem("title")
-        return title_node.firstChild().toText().data()
-
-    return None
-
-
 @lru_cache()
 def read_from_file(uri: str) -> Tuple[QtXml.QDomDocument, str]:
     """Read a QGIS project (.qgs and .qgz) from a file path and returns d

--- a/menu_from_project/logic/tools.py
+++ b/menu_from_project/logic/tools.py
@@ -3,9 +3,11 @@
 # Standard library
 import logging
 from functools import lru_cache
+from typing import Optional
 
 # PyQGIS
-from qgis.core import QgsApplication, QgsLayerItem
+from qgis.core import QgsApplication, QgsLayerItem, QgsMapLayerType, QgsWkbTypes
+from qgis.PyQt.QtGui import QIcon
 
 # project
 from menu_from_project.__about__ import DIR_PLUGIN_ROOT
@@ -90,3 +92,41 @@ def icon_per_geometry_type(geometry_type: str):
         return QgsLayerItem.iconTable()
     else:
         return QgsLayerItem.iconDefault()
+
+
+@lru_cache()
+def icon_per_layer_type(
+    is_spatial: bool,
+    layer_type: QgsMapLayerType,
+    geometry_type: Optional[QgsWkbTypes.GeometryType],
+) -> QIcon:
+    """Return a icon from a layer type
+
+    :param is_spatial: true if layer is spatial, false otherwise
+    :type is_spatial: bool
+    :param layer_type: layer type
+    :type layer_type: QgsMapLayerType
+    :param geometry_type: geometry type if layer is a QgsVectorLayer
+    :type geometry_type: Optional[QgsWkbTypes.GeometryType]
+    :return: icon for layer
+    :rtype: QIcon
+    """
+    if not is_spatial:
+        return QgsLayerItem.iconTable()
+    if layer_type == QgsMapLayerType.RasterLayer:
+        return QgsLayerItem.iconRaster()
+    elif layer_type == QgsMapLayerType.MeshLayer:
+        return QgsLayerItem.iconMesh()
+    elif layer_type == QgsMapLayerType.VectorTileLayer:
+        return QgsLayerItem.iconVectorTile()
+    elif layer_type == QgsMapLayerType.PointCloudLayer:
+        return QgsLayerItem.iconPointCloud()
+    elif layer_type == QgsMapLayerType.VectorLayer:
+        if geometry_type == QgsWkbTypes.GeometryType.PointGeometry:
+            return QgsLayerItem.iconPoint()
+        elif geometry_type == QgsWkbTypes.GeometryType.LineGeometry:
+            return QgsLayerItem.iconLine()
+        elif geometry_type == QgsWkbTypes.GeometryType.PolygonGeometry:
+            return QgsLayerItem.iconPolygon()
+        return QgsLayerItem.iconPoint()
+    return QgsLayerItem.iconDefault()

--- a/menu_from_project/logic/tools.py
+++ b/menu_from_project/logic/tools.py
@@ -62,39 +62,6 @@ def icon_per_storage_type(type_storage: str) -> str:
 
 
 @lru_cache()
-def icon_per_geometry_type(geometry_type: str):
-    """Return the icon for a geometry type.
-
-    If not found, it will return the default icon.
-
-    :param geometry_type: The geometry as a string.
-    :type geometry_type: basestring
-
-    :return: The icon.
-    :rtype: QIcon
-    """
-    geometry_type = geometry_type.lower()
-    if geometry_type == "raster":
-        return QgsLayerItem.iconRaster()
-    elif geometry_type == "mesh":
-        return QgsLayerItem.iconMesh()
-    elif geometry_type == "vector-tile":
-        return QgsLayerItem.iconVectorTile()
-    elif geometry_type == "point-cloud":
-        return QgsLayerItem.iconPointCloud()
-    elif geometry_type == "point":
-        return QgsLayerItem.iconPoint()
-    elif geometry_type == "line":
-        return QgsLayerItem.iconLine()
-    elif geometry_type == "polygon":
-        return QgsLayerItem.iconPolygon()
-    elif geometry_type == "no geometry":
-        return QgsLayerItem.iconTable()
-    else:
-        return QgsLayerItem.iconDefault()
-
-
-@lru_cache()
 def icon_per_layer_type(
     is_spatial: bool,
     layer_type: QgsMapLayerType,

--- a/menu_from_project/logic/xml_utils.py
+++ b/menu_from_project/logic/xml_utils.py
@@ -11,18 +11,3 @@ def getFirstChildByTagNameValue(elt, tagName, key, value):
             return node
 
     return None
-
-
-def getFirstChildByAttrValue(elt, tagName, key, value):
-    if isinstance(elt, QDomNode):
-        elt = elt.toElement()
-    nodes = elt.elementsByTagName(tagName)
-    for node in (nodes.at(i) for i in range(nodes.size())):
-        if (
-            node.toElement().hasAttribute(key)
-            and node.toElement().attribute(key) == value
-        ):
-            # layer founds
-            return node
-
-    return None

--- a/menu_from_project/logic/xml_utils.py
+++ b/menu_from_project/logic/xml_utils.py
@@ -1,0 +1,28 @@
+# PyQGIS
+from qgis.PyQt.QtXml import QDomNode
+
+
+def getFirstChildByTagNameValue(elt, tagName, key, value):
+    nodes = elt.elementsByTagName(tagName)
+    for node in (nodes.at(i) for i in range(nodes.size())):
+        nd = node.namedItem(key)
+        if nd and value == nd.firstChild().toText().data():
+            # layer founds
+            return node
+
+    return None
+
+
+def getFirstChildByAttrValue(elt, tagName, key, value):
+    if isinstance(elt, QDomNode):
+        elt = elt.toElement()
+    nodes = elt.elementsByTagName(tagName)
+    for node in (nodes.at(i) for i in range(nodes.size())):
+        if (
+            node.toElement().hasAttribute(key)
+            and node.toElement().attribute(key) == value
+        ):
+            # layer founds
+            return node
+
+    return None

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -753,7 +753,7 @@ class MenuFromProject:
         """
         # Get path to QgsProject file, local / downloaded / from postgres database
         uri = project["file"]
-        _, path = self.getQgsDoc(uri)
+        doc, path = self.getQgsDoc(uri)
 
         # Load QgsProject with specifics flags for faster parsing
         project_qgs = QgsProject()
@@ -766,7 +766,7 @@ class MenuFromProject:
         project_qgs.read(path, flags)
 
         # Create project menu configuration from QgsProject
-        project_config = get_project_menu_config(project_qgs, uri)
+        project_config = get_project_menu_config(project_qgs, uri, doc)
 
         # Define project name
         name = project["name"]
@@ -934,17 +934,25 @@ class MenuFromProject:
                 abstract = layer.metadata_abstract or layer.abstract
                 title = layer.metadata_title or layer.title
 
+            abstract = ""
+            title = ""
+            for oSource in self.optionSourceMD:
+                if oSource == MenuFromProject.SOURCE_MD_OGC:
+                    abstract = layer.metadata_abstract if abstract == "" else abstract
+                    title = title or layer.metadata_title
+
+                if oSource == MenuFromProject.SOURCE_MD_LAYER:
+                    abstract = layer.abstract if abstract == "" else abstract
+                    title = title or layer.title
+
+                if oSource == MenuFromProject.SOURCE_MD_NOTE:
+                    abstract = layer.layer_notes if abstract == "" else abstract
+
             if (abstract != "") and (title == ""):
-                action.setToolTip(
-                    "<p>{}</p>".format("<br/>".join(abstract.split("\n")))
-                )
+                action.setToolTip("<p>{}</p>".format(abstract))
             else:
                 if abstract != "" or title != "":
-                    action.setToolTip(
-                        "<b>{}</b><br/>{}".format(
-                            title, "<br/>".join(abstract.split("\n"))
-                        )
-                    )
+                    action.setToolTip("<b>{}</b><br/>{}".format(title, abstract))
                 else:
                     action.setToolTip("")
 


### PR DESCRIPTION
This PR refactor needed project information load to use `QgsProject` object instead of parsing XML content.

Instead of parsing XML and create menu during parsing, the operation is done in 2 steps:
- read needed information from `QgsProject` and store it in a specific dataclass (`MenuProjectConfig`)
- use this dataclass to create menu for layer load

Note : we can't only use information inside `QgsProject` because there is an issue with QGIS when reading project with some flags (see https://github.com/qgis/QGIS/issues/58818)