### PR TITLE
fix(project flags): invalid project flags definition for windows

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -413,7 +413,9 @@ class MenuFromProject:
 
         # Load QgsProject with specifics flags for faster parsing
         project_qgs = QgsProject()
-        flags = (
+        flags = QgsProject.ReadFlags()
+
+        flags |= (
             QgsProject.FlagDontResolveLayers
             | QgsProject.FlagDontLoadLayouts
             | QgsProject.FlagTrustLayerMetadata


### PR DESCRIPTION
Invalid use of flags for project load in Windows.

We must first create a `gsProject.ReadFlags` object.