### PR TITLE
feat: restore xml parsing to avoid postgis request

### DIFF
--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -1,21 +1,26 @@
 # standard
 from dataclasses import dataclass
-from typing import Any, List, Optional, Tuple
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
 # PyQGIS
 from qgis.PyQt import QtXml
+from qgis.PyQt.QtCore import QFileInfo
 from qgis.core import (
-    QgsLayerTreeNode,
     QgsMapLayerType,
-    QgsProject,
     QgsWkbTypes,
-    QgsLayerNotesUtils,
-    QgsReadWriteContext,
-    QgsMapLayer,
+    QgsMessageLog,
 )
 
 # project
-from menu_from_project.logic.xml_utils import getFirstChildByTagNameValue
+from menu_from_project.__about__ import __title__
+from menu_from_project.logic.xml_utils import getFirstChildByAttrValue
+from menu_from_project.logic.qgs_manager import (
+    QgsDomManager,
+    get_project_title,
+    create_map_layer_dict,
+    is_absolute,
+)
 
 
 @dataclass
@@ -29,7 +34,7 @@ class MenuLayerConfig:
     expanded: bool
     embedded: str
     is_spatial: bool
-    layer_type: QgsMapLayerType
+    layer_type: Optional[QgsMapLayerType]
     metadata_abstract: str
     metadata_title: str
     layer_notes: str
@@ -52,13 +57,14 @@ class MenuGroupConfig:
 class MenuProjectConfig:
     """Class to store configuration for project menu creation"""
 
+    project_name: str
     filename: str
     uri: str
     root_group: MenuGroupConfig
 
 
 def get_embedded_project_from_layer_tree(
-    layer_tree: QgsLayerTreeNode, project: QgsProject
+    node: QtXml.QDomNode, init_filename: str, absolute_project: bool
 ) -> str:
     """Get embedded project path from layer tree and his parent
 
@@ -69,16 +75,39 @@ def get_embedded_project_from_layer_tree(
     :return: path to embedded project
     :rtype: str
     """
-    filename = project.readPath(layer_tree.customProperty("embedded_project"))
-    if filename == "" and layer_tree.parent():
-        return get_embedded_project_from_layer_tree(
-            layer_tree=layer_tree.parent(), project=project
+    element = node.toElement()
+    eFileNd = getFirstChildByAttrValue(
+        element, "property", "key", "embedded_project"
+    ) or getFirstChildByAttrValue(element, "Option", "name", "embedded_project")
+    filename = ""
+    if eFileNd:
+        # get project file name
+        embeddedFile = eFileNd.toElement().attribute("value")
+        if not absolute_project and (embeddedFile.find(".") == 0):
+            filename = QFileInfo(init_filename).path() + "/" + embeddedFile
+        else:
+            filename = QFileInfo(embeddedFile).absoluteFilePath()
+    else:
+        layer_id = element.attribute("id")
+
+        QgsMessageLog.logMessage(
+            f"Menu from layer: Embeded project not found for {layer_id}",
+            __title__,
+            notifyUser=True,
         )
+        filename = ""
+    if filename == "" and not node.parentNode().isNull():
+        return get_embedded_project_from_layer_tree(
+            node.parentNode(),
+            init_filename=init_filename,
+            absolute_project=absolute_project,
+        )
+
     return filename
 
 
 def read_embedded_properties(
-    layer_tree: QgsLayerTreeNode, project: QgsProject
+    node: QtXml.QDomNode, init_filename: str, absolute_project: bool
 ) -> Tuple[bool, str]:
     """Read embedded properties from a QgsLayerTreeNode in a QgsProject
 
@@ -89,136 +118,295 @@ def read_embedded_properties(
     :return: Boolean indicating if the layer tree is embedded and the filename of the project used
     :rtype: Tuple[bool, str]
     """
-    # Embedded property is not read if QgsProject.FlagDontResolveLayers flag is use when reading QgsProject
-    if layer_tree.customProperty("embedded"):
+    element = node.toElement()
+    embedNd = getFirstChildByAttrValue(
+        element, "property", "key", "embedded"
+    ) or getFirstChildByAttrValue(element, "Option", "name", "embedded")
+
+    if embedNd and embedNd.toElement().attribute("value") == "1":
         embedded = True
         filename = get_embedded_project_from_layer_tree(
-            layer_tree=layer_tree, project=project
+            node=node, init_filename=init_filename, absolute_project=absolute_project
         )
     else:
         embedded = False
-        filename = project.absoluteFilePath()
+        filename = init_filename
     return embedded, filename
 
 
-def get_layer_user_notes(layer: QgsMapLayer, doc: QtXml.QDomDocument) -> str:
-    """Get layer user notes
+def get_layer_type_from_geometry_str(
+    geometry_type_str: str,
+) -> Tuple[Optional[QgsMapLayerType], Optional[QgsWkbTypes.GeometryType], bool]:
+    """Get layer type from geometry str
 
-    :param layer: layer
-    :type layer: QgsMapLayer
-    :param doc: xml doc for project
-    :type doc: QtXml.QDomDocument
-    :return: layer user notes
-    :rtype: str
+    :param geometry_type_str: geometry str in xml node
+    :type geometry_type_str: str
+    :return: layer_type, geometry_type, is_spatial
+    :rtype: Tuple[Optional[QgsMapLayerType], Optional[QgsWkbTypes.GeometryType], bool]
     """
-    # HACK for layer not vector the layer notes are not available
-    # see issue https://github.com/qgis/QGIS/issues/58818
-    # To have the value available we read directly from xml doc
-    if layer.type() != QgsMapLayerType.VectorLayer:
-        node = getFirstChildByTagNameValue(
-            doc.documentElement(), "maplayer", "id", layer.id()
+    geometry_type_str = geometry_type_str.lower()
+    if geometry_type_str == "raster":
+        return QgsMapLayerType.RasterLayer, None, True
+    elif geometry_type_str == "mesh":
+        return QgsMapLayerType.MeshLayer, None, True
+    elif geometry_type_str == "vector-tile":
+        return QgsMapLayerType.VectorTileLayer, None, True
+    elif geometry_type_str == "point-cloud":
+        return QgsMapLayerType.PointCloudLayer, None, True
+    elif geometry_type_str == "point":
+        return QgsMapLayerType.VectorLayer, QgsWkbTypes.GeometryType.PointGeometry, True
+    elif geometry_type_str == "line":
+        return QgsMapLayerType.VectorLayer, QgsWkbTypes.GeometryType.LineGeometry, True
+    elif geometry_type_str == "polygon":
+        return (
+            QgsMapLayerType.VectorLayer,
+            QgsWkbTypes.GeometryType.PolygonGeometry,
+            True,
         )
-        layer_notes = ""
-        elt_user_notes = node.namedItem("userNotes")
-        if elt_user_notes.toElement().hasAttribute("value"):
-            layer_notes = elt_user_notes.toElement().attribute("value")
-    else:
-        layer_notes = QgsLayerNotesUtils.layerNotes(layer)
-    return layer_notes
+    elif geometry_type_str == "no geometry":
+        return None, None, False
+    return None, None, False
 
 
 def get_layer_menu_config(
-    layer_tree: QgsLayerTreeNode, project: QgsProject, doc: QtXml.QDomDocument
+    node: QtXml.QDomNode,
+    maplayer_dict: Dict[str, QtXml.QDomNode],
+    qgs_dom_manager: QgsDomManager,
+    init_filename: str,
+    absolute_project: bool,
 ) -> MenuLayerConfig:
-    """Get layer menu configuration from a QgsLayerTreeNode in a QgsProject
+    """Get layer menu configuration from a xml node
 
-    :param layer_tree: layer tree to inspect
-    :type layer_tree: QgsLayerTreeNode
-    :param project: project where layer tree is used
-    :type project: QgsProject
-    :param doc: xml doc extracted from qgis project
-    :type doc: QtXml.QDomDocument
-    :return: Layer menu configuration
+    :param node: xml node
+    :type node: QtXml.QDomNode
+    :param maplayer_dict: dict of maplayer nodes
+    :type maplayer_dict: Dict[str, QtXml.QDomNode]
+    :param qgs_dom_manager: manager to get qgs doc for embedded project
+    :type qgs_dom_manager: QgsDomManager
+    :param init_filename: _description_
+    :param init_filename: initial filename of project
+    :type init_filename: str
+    :param absolute_project: True if project is absolute, False otherwise
+    :type absolute_project: bool
+    :return: layer menu configuration
     :rtype: MenuLayerConfig
     """
 
     embedded, filename = read_embedded_properties(
-        layer_tree=layer_tree, project=project
+        node=node, init_filename=init_filename, absolute_project=absolute_project
     )
 
-    # Get project map layer
-    layer = project.mapLayer(layer_tree.layerId())
+    element = node.toElement()
+    layer_id = element.attribute("id")
 
-    layer_notes = get_layer_user_notes(layer, doc)
+    if embedded:
+        ml = qgs_dom_manager.getMapLayerDomFromQgs(filename, layer_id)
+    else:
+        ml = maplayer_dict[layer_id]
+
+    if ml:
+        # Metadata infos
+        md = ml.namedItem("resourceMetadata")
+        metadata_title = md.namedItem("title").firstChild().toText().data()
+        metadata_abstract = md.namedItem("abstract").firstChild().toText().data()
+
+        # Layer info
+        title = ml.namedItem("title").firstChild().toText().data()
+        abstract = ml.namedItem("abstract").firstChild().toText().data()
+
+        # Layer notes
+        layer_notes = ""
+        elt_note = ml.namedItem("userNotes")
+        if elt_note.toElement().hasAttribute("value"):
+            layer_notes = elt_note.toElement().attribute("value")
+
+        # Geometry and layer type
+        ml_elem = ml.toElement()
+        geometry_type_str = ml_elem.attribute("geometry")
+        if geometry_type_str == "":
+            # A TMS has not a geometry attribute.
+            # Let's read the "type"
+            geometry_type_str = ml_elem.attribute("type")
+        layer_type, geometry_type, is_spatial = get_layer_type_from_geometry_str(
+            geometry_type_str
+        )
+    else:
+        metadata_abstract, metadata_title, title, abstract, layer_notes = ""
+        layer_type = None
+        geometry_type = None
+        is_spatial = False
 
     return MenuLayerConfig(
-        name=layer_tree.name(),
-        layer_id=layer_tree.layerId(),
+        name=element.attribute("name"),
+        layer_id=layer_id,
         filename=filename,
-        visible=layer_tree.itemVisibilityChecked(),
-        expanded=layer_tree.isExpanded(),
+        visible=element.attribute("checked", "") == "Qt::Checked",
+        expanded=element.attribute("expanded", "0") == "1",
         embedded=embedded,
-        layer_type=layer.type(),
-        metadata_abstract=layer.metadata().abstract(),
-        metadata_title=layer.metadata().title(),
-        abstract=layer.abstract(),
-        is_spatial=layer.isSpatial(),
-        title=layer.title(),
-        geometry_type=(
-            layer.geometryType()
-            if layer.type() == QgsMapLayerType.VectorLayer
-            else None
-        ),
+        layer_type=layer_type,
+        metadata_abstract=metadata_abstract,
+        metadata_title=metadata_title,
+        abstract=abstract,
+        is_spatial=is_spatial,
+        title=title,
+        geometry_type=geometry_type,
         layer_notes=layer_notes,
     )
 
 
-def get_group_menu_config(
-    layer_tree: QgsLayerTreeNode, project: QgsProject, doc: QtXml.QDomDocument
-) -> MenuGroupConfig:
-    """Get group menu configuration from a QgsLayerTreeNode in a QgsProject
+def get_embedded_group_config(
+    filename: str, group_name: str, qgs_dom_manager: QgsDomManager
+) -> Optional[MenuGroupConfig]:
+    """Get group menu configuration for an embedded group name
 
-    :param layer_tree: layer tree to inspect
-    :type layer_tree: QgsLayerTreeNode
-    :param project: project where layer tree is used
-    :type project: QgsProject
-    :param doc: xml doc extracted from qgis project
-    :type doc: QtXml.QDomDocument
-    :return: Group menu configuration
+    :param filename: embedded filename
+    :type filename: str
+    :param group_name: embedded group name
+    :type group_name: str
+    :param qgs_dom_manager: manager to get qgs doc for embedded project
+    :type qgs_dom_manager: QgsDomManager
+    :return: Optional menu group configuration
+    :rtype: Optional[MenuGroupConfig]
+    """
+    doc, _ = qgs_dom_manager.getQgsDoc(filename)
+    # Get layer tree root
+    layer_tree_roots = doc.elementsByTagName("layer-tree-group")
+    if layer_tree_roots.length() > 0:
+        if node := layer_tree_roots.item(0):
+            # Get all layer / group in tree
+            childrens = node.childNodes()
+            for i in range(0, childrens.size()):
+                child = childrens.at(i)
+                element = child.toElement()
+                name = element.attribute("name")
+                # Get only group with same name
+                if child.nodeName() == "layer-tree-group" and name == group_name:
+                    # Create dict of maplayer nodes
+                    maplayer_dict = create_map_layer_dict(doc)
+
+                    return get_group_menu_config(
+                        node=child,
+                        maplayer_dict=maplayer_dict,
+                        qgs_dom_manager=qgs_dom_manager,
+                        init_filename=filename,
+                        absolute_project=is_absolute(doc=doc),
+                    )
+
+    return None
+
+
+def get_group_menu_config(
+    node: QtXml.QDomNode,
+    maplayer_dict: Dict[str, QtXml.QDomNode],
+    qgs_dom_manager: QgsDomManager,
+    init_filename: str,
+    absolute_project: bool,
+) -> MenuGroupConfig:
+    """Get group menu configuration from a xml node
+
+    :param node: xml node
+    :type node: QtXml.QDomNode
+    :param maplayer_dict: dict of maplayer nodes
+    :type maplayer_dict: Dict[str, QtXml.QDomNode]
+    :param qgs_dom_manager: manager to get qgs doc for embedded project
+    :type qgs_dom_manager: QgsDomManager
+    :param init_filename: initial filename of project
+    :type init_filename: str
+    :param absolute_project: True if project is absolute, False otherwise
+    :type absolute_project: bool
+    :return: group menu configuration
     :rtype: MenuGroupConfig
     """
+
+    element = node.toElement()
+    name = element.attribute("name")
+
     embedded, filename = read_embedded_properties(
-        layer_tree=layer_tree, project=project
+        node=node, init_filename=init_filename, absolute_project=absolute_project
     )
 
     childs = []
 
-    for child in layer_tree.children():
-        if child.nodeType() == QgsLayerTreeNode.NodeGroup:
-            childs.append(get_group_menu_config(child, project, doc))
-        elif child.nodeType() == QgsLayerTreeNode.NodeLayer:
-            childs.append(get_layer_menu_config(child, project, doc))
+    # If embedded group, add all layer and subgroup from the group of same name
+    if embedded:
+        embedded_group = get_embedded_group_config(
+            filename=filename, group_name=name, qgs_dom_manager=qgs_dom_manager
+        )
+        if embedded_group:
+            childs += embedded_group.childs
+
+    childrens = node.childNodes()
+
+    for i in range(0, childrens.size()):
+        child = childrens.at(i)
+        if child.nodeName() == "layer-tree-group":
+            childs.append(
+                get_group_menu_config(
+                    node=child,
+                    maplayer_dict=maplayer_dict,
+                    qgs_dom_manager=qgs_dom_manager,
+                    init_filename=init_filename,
+                    absolute_project=absolute_project,
+                )
+            )
+        elif child.nodeName() == "layer-tree-layer":
+            childs.append(
+                get_layer_menu_config(
+                    node=child,
+                    maplayer_dict=maplayer_dict,
+                    qgs_dom_manager=qgs_dom_manager,
+                    init_filename=init_filename,
+                    absolute_project=absolute_project,
+                )
+            )
+
     return MenuGroupConfig(
-        name=layer_tree.name(), embedded=embedded, filename=filename, childs=childs
+        name=name, embedded=embedded, filename=filename, childs=childs
     )
 
 
 def get_project_menu_config(
-    qgs_project: QgsProject, uri: str, doc: QtXml.QDomDocument
-) -> MenuProjectConfig:
-    """Get project menu configuration from a QgsProject
+    project: Dict[str, str],
+    qgs_dom_manager: QgsDomManager,
+) -> Optional[MenuProjectConfig]:
+    """Get project menu configuration for a project
 
-    :param qgs_project: project
-    :type qgs_project: QgsProject
-    :param uri: initial uri of project (can be from local file / http / postgres)
-    :type uri: str
-    :param doc: xml doc extracted from qgis project
-    :type doc: QtXml.QDomDocument
-    :return: Project menu configuration
-    :rtype: MenuProjectConfig
+    :param project: dict of information about the project
+    :type project: Dict[str, str]
+    :param qgs_dom_manager: manager to get qgs doc for project
+    :type qgs_dom_manager: QgsDomManager
+    :return: Optional menu project configuration
+    :rtype: Optional[MenuProjectConfig]
     """
-    return MenuProjectConfig(
-        filename=qgs_project.absoluteFilePath(),
-        uri=uri,
-        root_group=get_group_menu_config(qgs_project.layerTreeRoot(), qgs_project, doc),
-    )
+
+    # Get path to QgsProject file, local / downloaded / from postgres database
+    uri = project["file"]
+    doc, filename = qgs_dom_manager.getQgsDoc(uri)
+
+    # Define project name
+    name = project["name"]
+    if name == "":
+        name = get_project_title(doc)
+    if name == "":
+        name = Path(filename).stem
+
+    # Get layer tree root
+    layer_tree_roots = doc.elementsByTagName("layer-tree-group")
+    if layer_tree_roots.length() > 0:
+        if node := layer_tree_roots.item(0):
+            # Create dict of maplayer nodes
+            maplayer_dict = create_map_layer_dict(doc)
+            # Parse node for group and layers
+            return MenuProjectConfig(
+                project_name=name,
+                filename=filename,
+                uri=uri,
+                root_group=get_group_menu_config(
+                    node=node,
+                    maplayer_dict=maplayer_dict,
+                    qgs_dom_manager=qgs_dom_manager,
+                    init_filename=filename,
+                    absolute_project=is_absolute(doc),
+                ),
+            )
+    return None

--- a/menu_from_project/logic/qgs_manager.py
+++ b/menu_from_project/logic/qgs_manager.py
@@ -10,11 +10,16 @@ import os
 import zipfile
 from functools import lru_cache
 from pathlib import Path
-from typing import Tuple
+from typing import Dict, Tuple
 from urllib.parse import urlparse
 
 # PyQGIS
-from qgis.core import QgsFileDownloader, QgsReadWriteContext, QgsMessageLog
+from qgis.core import (
+    QgsFileDownloader,
+    QgsReadWriteContext,
+    QgsMessageLog,
+    QgsApplication,
+)
 from qgis.PyQt import QtXml
 from qgis.PyQt.QtCore import (
     QDir,
@@ -27,11 +32,19 @@ from qgis.PyQt.QtCore import (
     QUrl,
 )
 
+# project
+from menu_from_project.logic.tools import guess_type_from_uri
+from menu_from_project.logic.xml_utils import getFirstChildByTagNameValue
+from menu_from_project.__about__ import __title__, __title_clean__
+
 # ############################################################################
 # ########## Globals ###############
 # ##################################
 
 logger = logging.getLogger(__name__)
+
+cache_folder = Path.home() / f".cache/QGIS/{__title_clean__}"
+cache_folder.mkdir(exist_ok=True, parents=True)
 
 
 # ############################################################################
@@ -57,6 +70,40 @@ def is_absolute(doc: QtXml.QDomDocument) -> bool:
         pass
 
     return absolute
+
+
+def create_map_layer_dict(doc: QtXml.QDomDocument) -> Dict[str, QtXml.QDomNode]:
+    """Create dict key : layer id, value : layer node
+
+    :param doc: input qgis project xml document
+    :type doc: QtXml.QDomDocument
+    :return: dict of layer id to layer node
+    :rtype: Dict[str, QtXml.QDomNode]
+    """
+    r = {}
+    nodes = doc.documentElement().elementsByTagName("maplayer")
+    for node in (nodes.at(i) for i in range(nodes.size())):
+        nd = node.namedItem("id")
+        if nd:
+            r[nd.firstChild().toText().data()] = node
+
+    return r
+
+
+def get_project_title(doc: QtXml.QDomDocument) -> str:
+    """Return the project title defined in the XML document.
+    :param doc: The QGIS project as XML document. Default to None.
+    :type doc: QDomDocument
+    :return: The title or None.
+    :rtype: string
+    """
+    tags = doc.elementsByTagName("qgis")
+    if tags.count():
+        node = tags.at(0)
+        title_node = node.namedItem("title")
+        return title_node.firstChild().toText().data()
+
+    return None
 
 
 @lru_cache()
@@ -165,3 +212,67 @@ def read_from_http(uri: str, cache_folder: Path):
     loop.exec_()
 
     return read_from_file(str(cached_filepath))
+
+
+class QgsDomManager:
+    """Manager to access qgs xml document for different type of uri:
+    - file
+    - postgres
+    - url
+    Read xml document are stored in a dict.
+    """
+
+    def __init__(self) -> None:
+        self.docs = dict()
+        self.project_registry = QgsApplication.projectStorageRegistry()
+
+    def getQgsDoc(self, uri):
+        """Return the XML document and the path from an URI.
+
+        The URI can be a filepath or stored in database.
+
+        :param uri: The URI to fetch.
+        :type uri: basestring
+
+        :return: Tuple with XML document and the filepath.
+        :rtype: (QDomDocument, basestring)
+        """
+        # determine storage type: file, database or http
+        qgs_storage_type = guess_type_from_uri(uri)
+
+        # check if docs is already here
+        if uri in self.docs:
+            return self.docs[uri], uri
+
+        if qgs_storage_type == "file":
+            doc, project_path = read_from_file(uri)
+        elif qgs_storage_type == "database":
+            doc, project_path = read_from_database(uri, self.project_registry)
+        elif qgs_storage_type == "http":
+            doc, project_path = read_from_http(uri, cache_folder)
+        else:
+            QgsMessageLog.logMessage(
+                f"Unrecognized project type: {uri}", __title__, notifyUser=True
+            )
+
+        # store doc into the plugin registry
+        self.docs[project_path] = doc
+
+        return doc, project_path
+
+    def getMapLayerDomFromQgs(self, fileName, layerId):
+        """Return the maplayer node in a project filepath given a maplayer ID.
+
+        :param fileName: The project filepath on the filesystem.
+        :type fileName: basestring
+
+        :param layerId: The layer ID to look for in the project.
+        :type layerId: basestring
+
+        :return: The XML node of the layer.
+        :rtype: QDomNode
+        """
+        doc, _ = self.getQgsDoc(fileName)
+        return getFirstChildByTagNameValue(
+            doc.documentElement(), "maplayer", "id", layerId
+        )

--- a/menu_from_project/logic/xml_utils.py
+++ b/menu_from_project/logic/xml_utils.py
@@ -2,6 +2,21 @@
 from qgis.PyQt.QtXml import QDomNode
 
 
+def getFirstChildByAttrValue(elt, tagName, key, value):
+    if isinstance(elt, QDomNode):
+        elt = elt.toElement()
+    nodes = elt.elementsByTagName(tagName)
+    for node in (nodes.at(i) for i in range(nodes.size())):
+        if (
+            node.toElement().hasAttribute(key)
+            and node.toElement().attribute(key) == value
+        ):
+            # layer founds
+            return node
+
+    return None
+
+
 def getFirstChildByTagNameValue(elt, tagName, key, value):
     nodes = elt.elementsByTagName(tagName)
     for node in (nodes.at(i) for i in range(nodes.size())):

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -47,8 +47,8 @@ from qgis.utils import plugins
 # project
 from .__about__ import DIR_PLUGIN_ROOT, __title__, __title_clean__
 from .logic.qgs_manager import (
+    QgsDomManager,
     is_absolute,
-    read_from_database,
     read_from_file,
     read_from_http,
 )
@@ -70,8 +70,6 @@ from menu_from_project.logic.xml_utils import getFirstChildByTagNameValue
 # ##################################
 
 logger = logging.getLogger(__name__)
-cache_folder = Path.home() / f".cache/QGIS/{__title_clean__}"
-cache_folder.mkdir(exist_ok=True, parents=True)
 
 # ############################################################################
 # ########## Functions #############
@@ -163,11 +161,10 @@ class MenuFromProject:
 
         self.iface = iface
         self.toolBar = None
-        self.project_registry = QgsApplication.projectStorageRegistry()
 
         # new multi projects var
         self.projects = []
-        self.docs = dict()
+        self.qgs_dom_manager = QgsDomManager()
         self.menubarActions = []
         self.layerMenubarActions = []
         self.canvas = self.iface.mapCanvas()
@@ -315,55 +312,6 @@ class MenuFromProject:
 
         except Exception:
             pass
-
-    def getQgsDoc(self, uri):
-        """Return the XML document and the path from an URI.
-
-        The URI can be a filepath or stored in database.
-
-        :param uri: The URI to fetch.
-        :type uri: basestring
-
-        :return: Tuple with XML document and the filepath.
-        :rtype: (QDomDocument, basestring)
-        """
-        # determine storage type: file, database or http
-        qgs_storage_type = guess_type_from_uri(uri)
-
-        # check if docs is already here
-        if uri in self.docs:
-            return self.docs[uri], uri
-
-        if qgs_storage_type == "file":
-            doc, project_path = read_from_file(uri)
-        elif qgs_storage_type == "database":
-            doc, project_path = read_from_database(uri, self.project_registry)
-        elif qgs_storage_type == "http":
-            doc, project_path = read_from_http(uri, cache_folder)
-        else:
-            self.log(f"Unrecognized project type: {uri}")
-
-        # store doc into the plugin registry
-        self.docs[project_path] = doc
-
-        return doc, project_path
-
-    def getMapLayerDomFromQgs(self, fileName, layerId):
-        """Return the maplayer node in a project filepath given a maplayer ID.
-
-        :param fileName: The project filepath on the filesystem.
-        :type fileName: basestring
-
-        :param layerId: The layer ID to look for in the project.
-        :type layerId: basestring
-
-        :return: The XML node of the layer.
-        :rtype: QDomNode
-        """
-        doc, _ = self.getQgsDoc(fileName)
-        return getFirstChildByTagNameValue(
-            doc.documentElement(), "maplayer", "id", layerId
-        )
 
     def initMenus(self):
         menuBar = self.iface.editMenu().parentWidget()
@@ -1012,7 +960,7 @@ class MenuFromProject:
                     ):
                         action.trigger()
             else:
-                doc, _ = self.getQgsDoc(fileName)
+                doc, _ = self.qgs_dom_manager.getQgsDoc(fileName)
 
                 # Loading layer
                 layer, relationsToBuild = self.addLayer(

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -355,38 +355,17 @@ class MenuFromProject:
         :return: created menu
         :rtype: QMenu
         """
-        # Get path to QgsProject file, local / downloaded / from postgres database
-        uri = project["file"]
-        doc, path = self.getQgsDoc(uri)
-
-        # Load QgsProject with specifics flags for faster parsing
-        project_qgs = QgsProject()
-        flags = (
-            QgsProject.FlagDontResolveLayers
-            | QgsProject.FlagDontLoadLayouts
-            | QgsProject.FlagTrustLayerMetadata
-            | QgsProject.FlagDontStoreOriginalStyles
-        )
-        project_qgs.read(path, flags)
 
         # Create project menu configuration from QgsProject
-        project_config = get_project_menu_config(project_qgs, uri, doc)
-
-        # Define project name
-        name = project["name"]
-        if name == "":
-            name = project_qgs.title()
-        if name == "":
-            name = Path(path).stem
+        project_config = get_project_menu_config(project, self.qgs_dom_manager)
 
         # Add to QGIS instance
-        previous = self.add_project_config(name, project, project_config, previous)
+        previous = self.add_project_config(project, project_config, previous)
 
         return previous
 
     def add_project_config(
         self,
-        menu_name: str,
         project: Dict[str, str],
         project_config: MenuProjectConfig,
         previous: Optional[QMenu],
@@ -405,7 +384,7 @@ class MenuFromProject:
         :rtype: QMenu
         """
         project_menu = self.create_project_menu(
-            menu_name=menu_name, project=project, previous=previous
+            menu_name=project_config.project_name, project=project, previous=previous
         )
         self.add_group_childs(project_config.root_group, project_menu)
 

--- a/menu_from_project/ui/menu_conf_dlg.py
+++ b/menu_from_project/ui/menu_conf_dlg.py
@@ -246,7 +246,9 @@ class MenuConfDialog(QDialog, FORM_CLASS):
 
         filePath = QFileDialog.getOpenFileName(
             self,
-            QgsApplication.translate("menu_from_project", "Projects configuration", None),
+            QgsApplication.translate(
+                "menu_from_project", "Projects configuration", None
+            ),
             file_widget.text(),
             QgsApplication.translate(
                 "menu_from_project", "QGIS projects (*.qgs *.qgz)", None
@@ -279,7 +281,9 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         """
         self.plugin.iface.messageBar().pushMessage(
             "Message",
-            self.tr("No HTTP Browser, simply paste your URL into the 'project' column."),
+            self.tr(
+                "No HTTP Browser, simply paste your URL into the 'project' column."
+            ),
             level=Qgis.Info,
         )
 
@@ -382,7 +386,9 @@ class MenuConfDialog(QDialog, FORM_CLASS):
                 location_combo.addItem(self.LOCATIONS[pk]["label"], pk)
 
         location_combo.setCurrentIndex(0)
-        self.tableWidget.setCellWidget(row, self.cols.type_menu_location, location_combo)
+        self.tableWidget.setCellWidget(
+            row, self.cols.type_menu_location, location_combo
+        )
 
         # project file path
         itemFile = QTableWidgetItem()
@@ -534,7 +540,7 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         """
         file_widget = self.sender()
         try:
-            self.plugin.getQgsDoc(text)
+            self.plugin.qgs_dom_manager.getQgsDoc(text)
             file_widget.setStyleSheet("color: {};".format("black"))
         except Exception as err:
             self.plugin.log("Error during project reading: {}".format(err))


### PR DESCRIPTION
Even with the use of flags `QgsProject.FlagDontResolveLayers | QgsProject.FlagDontLoadLayouts
            | QgsProject.FlagTrustLayerMetadata
            | QgsProject.FlagDontStoreOriginalStyles
        ` we still see some request to postgis if there are postgis layer in the project.

If the number of layer is big this really increase project load time.

To avoid that this PR restore the use of xml parsing for project menu configuration definition.

- A new class `QgsDomManager` is created to store all the loaded xml projects (was previously in plugin main):
    - This allow us to use this class in other part of plugin that the plugin main.
- Full refactoring of `project_read.py` to use xml parsing.