### PR TITLE
Feat add cache options

### DIFF
--- a/menu_from_project/datamodel/project.py
+++ b/menu_from_project/datamodel/project.py
@@ -3,9 +3,20 @@ from typing import Optional
 
 
 @dataclass
+class ProjectCacheConfig:
+    """Project cache configuration"""
+
+    enable: bool = True
+    refresh_days_period: Optional[int] = None
+
+
+@dataclass
 class Project:
+    """All information for project"""
+
     name: str
     location: str
     file: str
     type_storage: str
     valid: bool = True
+    cache_config: ProjectCacheConfig = ProjectCacheConfig()

--- a/menu_from_project/datamodel/project.py
+++ b/menu_from_project/datamodel/project.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class Project:
+    name: str
+    location: str
+    file: str
+    type_storage: str
+    valid: bool = True

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -2,9 +2,10 @@
 from dataclasses import asdict
 import json
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 # project
+from menu_from_project.datamodel.project import Project
 from menu_from_project.datamodel.project_config import MenuProjectConfig
 
 
@@ -18,13 +19,11 @@ class CacheManager:
     def __init__(self, iface) -> None:
         self.iface = iface
 
-    def get_project_menu_config(
-        self, project: Dict[str, str]
-    ) -> Optional[MenuProjectConfig]:
+    def get_project_menu_config(self, project: Project) -> Optional[MenuProjectConfig]:
         """Get menu project configuration from cache for a project
 
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :return: menu project configuration from cache, None if no cache available
         :rtype: Optional[MenuProjectConfig]
         """
@@ -37,39 +36,38 @@ class CacheManager:
         return None
 
     def save_project_menu_config(
-        self, project: Dict[str, str], project_config: MenuProjectConfig
+        self, project: Project, project_config: MenuProjectConfig
     ) -> None:
         """Save menu project configuration in cache
 
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :param project_config: menu project configuration
         :type project_config: MenuProjectConfig
         """
         cache_path = self.get_project_cache_dir(project)
         json_cache_path = cache_path / "project_config.json"
-
         with open(json_cache_path, "w", encoding="UTF-8") as f:
             json.dump(asdict(project_config), f, indent=4)
 
-    def get_project_cache_dir(self, project: Dict[str, str]) -> Path:
+    def get_project_cache_dir(self, project: Project) -> Path:
         """Get local project cache directory
 
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :return: path to project cache directory
         :rtype: Path
         """
         cache_path = Path(self.iface.userProfileManager().userProfile().folder())
-        cache_path = cache_path / ".cache" / "menu-layer" / project["name"]
+        cache_path = cache_path / ".cache" / "menu-layer" / project.name
         cache_path.mkdir(parents=True, exist_ok=True)
         return cache_path
 
-    def get_project_download_dir(self, project: Dict[str, str]) -> Path:
+    def get_project_download_dir(self, project: Project) -> Path:
         """Get local project cache download directory
 
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :return: path to project cache directory
         :rtype: Path
         """

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -1,10 +1,16 @@
 # standard
 from dataclasses import asdict
+from datetime import datetime, timedelta
 import json
 from pathlib import Path
 from typing import Optional
 
+# PyQGIS
+from qgis.core import QgsMessageLog
+from qgis.PyQt.QtCore import QCoreApplication
+
 # project
+from menu_from_project.__about__ import __title__
 from menu_from_project.datamodel.project import Project
 from menu_from_project.datamodel.project_config import MenuProjectConfig
 
@@ -16,8 +22,57 @@ class CacheManager:
     :type iface: QgsInterface
     """
 
+    DATETIME_FORMAT = "%d/%m/%Y %H:%M:%S"
+
     def __init__(self, iface) -> None:
         self.iface = iface
+
+    @staticmethod
+    def tr(message):
+        return QCoreApplication.translate("MenuFromProject", message)
+
+    @staticmethod
+    def log(message, application=__title__, indent=0):
+        indent_chars = " .. " * indent
+        QgsMessageLog.logMessage(
+            f"{indent_chars}{message}", application, notifyUser=True
+        )
+
+    def check_if_cache_enabled(self, project: Project) -> bool:
+        """Check if cache is enabled for project
+
+        :param project: project
+        :type project: Project
+        :return: True if cache is enabled, False otherwise
+        :rtype: bool
+        """
+        cache_config = project.cache_config
+        if not cache_config.enable:
+            self.log(self.tr("Cache disabled for project {project.name}"))
+            return False
+
+        # Check if a cache info is available
+        cache_info = {}
+        cache_path = self.get_project_cache_dir(project)
+        cache_info_path = cache_path / "cache_info.json"
+        if cache_info_path.exists():
+            with open(cache_info_path, encoding="UTF-8") as f:
+                cache_info = json.load(f)
+        if "last_refresh" in cache_info and cache_config.refresh_days_period:
+            cache_last_refresh = datetime.strptime(
+                cache_info["last_refresh"], self.DATETIME_FORMAT
+            )
+            refresh_date = cache_last_refresh + timedelta(
+                days=cache_config.refresh_days_period
+            )
+            if datetime.now() > refresh_date:
+                self.log(
+                    self.tr(
+                        f"Cache is not up to date since {refresh_date} for project {project.name}."
+                    )
+                )
+                return False
+        return True
 
     def get_project_menu_config(self, project: Project) -> Optional[MenuProjectConfig]:
         """Get menu project configuration from cache for a project
@@ -28,6 +83,12 @@ class CacheManager:
         :rtype: Optional[MenuProjectConfig]
         """
         cache_path = self.get_project_cache_dir(project)
+        if not self.check_if_cache_enabled(project):
+            self.log(
+                self.tr(f"Cache disabled for project {project.name}. Reloading data.")
+            )
+            return None
+
         json_cache_path = cache_path / "project_config.json"
         if json_cache_path.exists():
             with open(json_cache_path, "r", encoding="UTF-8") as f:
@@ -49,6 +110,14 @@ class CacheManager:
         json_cache_path = cache_path / "project_config.json"
         with open(json_cache_path, "w", encoding="UTF-8") as f:
             json.dump(asdict(project_config), f, indent=4)
+
+        cache_info_path = cache_path / "cache_info.json"
+        with open(cache_info_path, "w", encoding="UTF-8") as f:
+            json.dump(
+                {"last_refresh": datetime.now().strftime(self.DATETIME_FORMAT)},
+                f,
+                indent=4,
+            )
 
     def get_project_cache_dir(self, project: Project) -> Path:
         """Get local project cache directory

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -48,7 +48,7 @@ class CacheManager:
         """
         cache_config = project.cache_config
         if not cache_config.enable:
-            self.log(self.tr("Cache disabled for project {project.name}"))
+            self.log(self.tr(f"Cache disabled for project {project.name}"))
             return False
 
         # Check if a cache info is available

--- a/menu_from_project/logic/custom_datatypes.py
+++ b/menu_from_project/logic/custom_datatypes.py
@@ -9,5 +9,14 @@ REGISTERED_PROJECT = namedtuple(
 )
 
 TABLE_COLUMNS_ORDER = namedtuple(
-    "ColumnsIndex", ["edit", "name", "type_menu_location", "type_storage", "uri"]
+    "ColumnsIndex",
+    [
+        "edit",
+        "name",
+        "type_menu_location",
+        "type_storage",
+        "uri",
+        "refresh_days",
+        "enable_cache",
+    ],
 )

--- a/menu_from_project/logic/project_read.py
+++ b/menu_from_project/logic/project_read.py
@@ -13,6 +13,7 @@ from qgis.core import (
 
 # project
 from menu_from_project.__about__ import __title__
+from menu_from_project.datamodel.project import Project
 from menu_from_project.logic.xml_utils import getFirstChildByAttrValue
 from menu_from_project.logic.qgs_manager import (
     QgsDomManager,
@@ -342,13 +343,13 @@ def get_group_menu_config(
 
 
 def get_project_menu_config(
-    project: Dict[str, str],
+    project: Project,
     qgs_dom_manager: QgsDomManager,
 ) -> Optional[MenuProjectConfig]:
     """Get project menu configuration for a project
 
     :param project: dict of information about the project
-    :type project: Dict[str, str]
+    :type project: Project
     :param qgs_dom_manager: manager to get qgs doc for project
     :type qgs_dom_manager: QgsDomManager
     :return: Optional menu project configuration
@@ -356,12 +357,12 @@ def get_project_menu_config(
     """
 
     # Get path to QgsProject file, local / downloaded / from postgres database
-    uri = project["file"]
+    uri = project.file
     qgs_dom_manager.set_project(project)
     doc, filename = qgs_dom_manager.getQgsDoc(uri)
 
     # Define project name
-    name = project["name"]
+    name = project.name
     if name == "":
         name = get_project_title(doc)
     if name == "":

--- a/menu_from_project/logic/qgs_manager.py
+++ b/menu_from_project/logic/qgs_manager.py
@@ -240,6 +240,10 @@ class QgsDomManager:
         self.project = project
         self.cache_manager = CacheManager(iface)
 
+    def cache_clear(self) -> None:
+        """Clear cache of QtXml.QDomDocument for uri"""
+        self.docs = dict()
+
     def set_project(self, project: Optional[Dict[str, str]]) -> None:
         """Define project used to check cache in project cache directory
 

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -24,6 +24,7 @@ import os
 from typing import Dict, Optional, List, Tuple, Any
 
 # PyQGIS
+from menu_from_project.datamodel.project import Project
 from menu_from_project.logic.cache_manager import CacheManager
 from menu_from_project.logic.layer_load import LayerLoad
 from menu_from_project.toolbelt.preferences import (
@@ -233,7 +234,7 @@ class MenuFromProject:
 
     def add_project_config(
         self,
-        project: Dict[str, str],
+        project: Project,
         project_config: MenuProjectConfig,
         previous: Optional[QMenu],
     ) -> QMenu:
@@ -242,7 +243,7 @@ class MenuFromProject:
         :param menu_name: Name of the menu to create
         :type menu_name: str
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :param project_config: project menu configuration
         :type project_config: MenuProjectConfig
         :param previous: previous created menu
@@ -258,20 +259,20 @@ class MenuFromProject:
         return project_menu
 
     def create_project_menu(
-        self, menu_name: str, project: Dict[str, str], previous: Optional[QMenu]
+        self, menu_name: str, project: Project, previous: Optional[QMenu]
     ) -> QMenu:
         """Create project menu and add it to QGIS instance
 
         :param menu_name: Name of the menu to create
         :type menu_name: str
         :param project: dict of information about the project
-        :type project: Dict[str, str]
+        :type project: Project
         :param previous: previous created menu
         :type previous: Optional[QMenu]
         :return: created menu
         :rtype: QMenu
         """
-        location = project["location"]
+        location = project.location
         if location == "merge" and previous:
             project_menu = previous
             project_menu.addSeparator()

--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -483,6 +483,7 @@ class MenuFromProject:
         if result != 0:
             # clear web projects cache
             try:
+                self.qgs_dom_manager.cache_clear()
                 read_from_http.cache_clear()
                 read_from_file.cache_clear()
             except Exception:

--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -13,7 +13,7 @@ from qgis.core import QgsSettings
 
 # package
 from menu_from_project.__about__ import __title__, __version__
-from menu_from_project.datamodel.project import Project
+from menu_from_project.datamodel.project import Project, ProjectCacheConfig
 from menu_from_project.logic.tools import guess_type_from_uri
 
 # ############################################################################
@@ -131,6 +131,14 @@ class PlgOptionsManager:
                         type_storage = s.value(
                             "type_storage", guess_type_from_uri(file)
                         )
+
+                        s.beginGroup("cache_config")
+                        cache_config = ProjectCacheConfig(
+                            refresh_days_period=s.value("refresh_days_period", None),
+                            enable=s.value("enable", True),
+                        )
+                        s.endGroup()
+
                         if file != "":
                             options.projects.append(
                                 Project(
@@ -138,6 +146,7 @@ class PlgOptionsManager:
                                     name=name,
                                     location=location,
                                     type_storage=type_storage,
+                                    cache_config=cache_config,
                                 )
                             )
                 finally:
@@ -176,6 +185,13 @@ class PlgOptionsManager:
                     s.setValue("name", project.name)
                     s.setValue("location", project.location)
                     s.setValue("type_storage", guess_type_from_uri(project.file))
+
+                    s.beginGroup("cache_config")
+                    s.setValue(
+                        "refresh_days_period", project.cache_config.refresh_days_period
+                    )
+                    s.setValue("enable", project.cache_config.enable)
+                    s.endGroup()
             finally:
                 s.endArray()
         finally:

--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -13,6 +13,7 @@ from qgis.core import QgsSettings
 
 # package
 from menu_from_project.__about__ import __title__, __version__
+from menu_from_project.datamodel.project import Project
 from menu_from_project.logic.tools import guess_type_from_uri
 
 # ############################################################################
@@ -33,7 +34,7 @@ class PlgSettingsStructure:
     version: str = __version__
 
     # Projects
-    projects: List[dict[str, str]] = field(default_factory=lambda: [])
+    projects: List[Project] = field(default_factory=lambda: [])
 
     # Menu option
     optionTooltip: bool = False
@@ -132,12 +133,12 @@ class PlgOptionsManager:
                         )
                         if file != "":
                             options.projects.append(
-                                {
-                                    "file": file,
-                                    "name": name,
-                                    "location": location,
-                                    "type_storage": type_storage,
-                                }
+                                Project(
+                                    file=file,
+                                    name=name,
+                                    location=location,
+                                    type_storage=type_storage,
+                                )
                             )
                 finally:
                     s.endArray()
@@ -171,16 +172,10 @@ class PlgOptionsManager:
             try:
                 for i, project in enumerate(plugin_settings_obj.projects):
                     s.setArrayIndex(i)
-                    s.setValue("file", project["file"])
-                    s.setValue("name", project["name"])
-                    s.setValue("location", project["location"])
-                    s.setValue(
-                        "type_storage",
-                        project.get(
-                            "type_storage",
-                            guess_type_from_uri(project.get("file")),
-                        ),
-                    )
+                    s.setValue("file", project.file)
+                    s.setValue("name", project.name)
+                    s.setValue("location", project.location)
+                    s.setValue("type_storage", guess_type_from_uri(project.file))
             finally:
                 s.endArray()
         finally:

--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -134,8 +134,10 @@ class PlgOptionsManager:
 
                         s.beginGroup("cache_config")
                         cache_config = ProjectCacheConfig(
-                            refresh_days_period=s.value("refresh_days_period", None),
-                            enable=s.value("enable", True),
+                            refresh_days_period=s.value(
+                                "refresh_days_period", None, type=int
+                            ),
+                            enable=s.value("enable", True, type=bool),
                         )
                         s.endGroup()
 

--- a/menu_from_project/ui/conf_dialog.ui
+++ b/menu_from_project/ui/conf_dialog.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>660</width>
+    <width>828</width>
     <height>310</height>
    </rect>
   </property>
@@ -98,7 +98,7 @@
         <number>1</number>
        </property>
        <property name="columnCount">
-        <number>5</number>
+        <number>7</number>
        </property>
        <attribute name="horizontalHeaderVisible">
         <bool>true</bool>
@@ -145,6 +145,16 @@
        <column>
         <property name="text">
          <string>QGIS Project</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Refresh interval</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Enable cache</string>
         </property>
        </column>
       </widget>

--- a/menu_from_project/ui/menu_conf_dlg.py
+++ b/menu_from_project/ui/menu_conf_dlg.py
@@ -9,6 +9,7 @@ import logging
 from functools import partial
 
 # PyQGIS
+from menu_from_project.datamodel.project import Project
 from menu_from_project.logic.qgs_manager import QgsDomManager
 from menu_from_project.toolbelt.preferences import (
     SOURCE_MD_LAYER,
@@ -145,14 +146,14 @@ class MenuConfDialog(QDialog, FORM_CLASS):
 
         for idx, project in enumerate(settings.projects):
             # edit project
-            self.addEditButton(idx, guess_type_from_uri(project.get("file")))
+            self.addEditButton(idx, guess_type_from_uri(project.file))
 
             # project name
-            itemName = QTableWidgetItem(project.get("name"))
+            itemName = QTableWidgetItem(project.name)
             itemName.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
             self.tableWidget.setItem(idx, self.cols.name, itemName)
             le = QLineEdit()
-            le.setText(project.get("name"))
+            le.setText(project.name)
             le.setPlaceholderText(self.tr("Use project title"))
             self.tableWidget.setCellWidget(idx, self.cols.name, le)
 
@@ -160,7 +161,7 @@ class MenuConfDialog(QDialog, FORM_CLASS):
             self.tableWidget.setCellWidget(
                 idx,
                 self.cols.type_storage,
-                self.mk_prj_storage_icon(guess_type_from_uri(project.get("file"))),
+                self.mk_prj_storage_icon(guess_type_from_uri(project.file)),
             )
 
             # project menu location
@@ -171,7 +172,7 @@ class MenuConfDialog(QDialog, FORM_CLASS):
 
             try:
                 location_combo.setCurrentIndex(
-                    self.LOCATIONS[project["location"]]["index"]
+                    self.LOCATIONS[project.location]["index"]
                 )
             except Exception:
                 location_combo.setCurrentIndex(0)
@@ -180,15 +181,15 @@ class MenuConfDialog(QDialog, FORM_CLASS):
             )
 
             # project path (guess type stored into data)
-            itemFile = QTableWidgetItem(project.get("file"))
-            itemFile.setData(Qt.UserRole, guess_type_from_uri(project.get("file")))
+            itemFile = QTableWidgetItem(project.file)
+            itemFile.setData(Qt.UserRole, guess_type_from_uri(project.file))
             itemFile.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
             self.tableWidget.setItem(idx, self.cols.uri, itemFile)
             le = QLineEdit()
-            le.setText(project.get("file"))
+            le.setText(project.file)
             try:
                 le.setStyleSheet(
-                    "color: {};".format("black" if project["valid"] else "red")
+                    "color: {};".format("black" if project.valid else "red")
                 )
             except Exception:
                 le.setStyleSheet("color: {};".format("black"))
@@ -357,7 +358,13 @@ class MenuConfDialog(QDialog, FORM_CLASS):
                 location = location_widget.itemData(location_widget.currentIndex())
 
                 settings.projects.append(
-                    {"file": filename, "name": name, "location": location}
+                    Project(
+                        file=filename,
+                        name=name,
+                        location=location,
+                        valid=False,
+                        type_storage=guess_type_from_uri(filename),
+                    )
                 )
 
         settings.optionTooltip = self.cbxShowTooltip.isChecked()

--- a/menu_from_project/ui/menu_conf_dlg.py
+++ b/menu_from_project/ui/menu_conf_dlg.py
@@ -372,7 +372,9 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         settings = self.plg_settings.get_plg_settings()
         settings.projects = []
         for row in range(self.tableWidget.rowCount()):
-            if project := self._table_widget_row_project(row):
+            project = self._table_widget_row_project(row)
+            # Only get project with file defined
+            if project.file:
                 settings.projects.append(project)
 
         settings.optionTooltip = self.cbxShowTooltip.isChecked()

--- a/tests/qgis/test_project_read.py
+++ b/tests/qgis/test_project_read.py
@@ -24,6 +24,7 @@ from menu_from_project.datamodel.project_config import (
 )
 from menu_from_project.logic.project_read import get_project_menu_config
 from menu_from_project.logic.qgs_manager import QgsDomManager
+from menu_from_project.datamodel.project import Project
 
 
 # ############################################################################
@@ -37,19 +38,22 @@ class TestProjectMenuConfig(unittest.TestCase):
 
         qgs_dom_manager = QgsDomManager()
         filename = str(Path(__file__).parent / ".." / "projets" / "aeag-tiny.qgz")
-        project = {
-            "file": filename,
-            "name": "test_import",
-        }
+
+        project = Project(
+            name="test_import",
+            location="layer",
+            file=filename,
+            type_storage="file",
+        )
 
         result = get_project_menu_config(
             project=project, qgs_dom_manager=qgs_dom_manager
         )
 
         expected = MenuProjectConfig(
-            project_name="test_import",
+            project_name=project.name,
             filename=filename,
-            uri=project["file"],
+            uri=project.file,
             root_group=MenuGroupConfig(
                 name="",
                 filename=filename,


### PR DESCRIPTION
Add new option for project cache management
- enable : define if cache must be used
- refresh_days_period : define how often cache must be reloaded

## Added

- create a new file `cache_info.json` in project cache folder after cache creation/update. We indicate the refresh date in `last_refresh`.
- when asking for cache, we check if cache is enabled:
    - enable option is True
    - if `last_refresh` date is available and a refresh_day_period is defined, we check if `datetime.now()  < `last_refresh` + `refresh_day_period`
- update `QgsDomManager` to be able to clear cache when configuration is updated
- created a dataclass `Project` to store all information related to project

## Refactoring

To be able to add new parameters in project configuration, a small refactoring of `MenuConfDialog` was done.

3 functions were extracted from previous code:
- `_set_table_widget_row_project` : create all cell widget to be used in `QTableWidget`
- `_set_table_widget_row_project` : define all cell widget content from a project
- `_table_widget_row_project`: get a project information from a `QTableWidget` row

Functions to move up and down row where also updated to use new function `_table_widget_row_project`
