### PR TITLE
fix(dataclass): use field and default_factory for default value

### DIFF
--- a/menu_from_project/datamodel/project.py
+++ b/menu_from_project/datamodel/project.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -19,4 +19,4 @@ class Project:
     file: str
     type_storage: str
     valid: bool = True
-    cache_config: ProjectCacheConfig = ProjectCacheConfig()
+    cache_config: ProjectCacheConfig = field(default_factory=lambda: ProjectCacheConfig())


### PR DESCRIPTION
On python 3.12 you can't use mutable default type:

```
raise ValueError(f'mutable default {type(f.default)} for field '
             ValueError: mutable default for field cache_config is not allowed: use default_factory
```