### PR TITLE
feat(cache): add cache validation uri support

### DIFF
--- a/menu_from_project/datamodel/project.py
+++ b/menu_from_project/datamodel/project.py
@@ -8,6 +8,7 @@ class ProjectCacheConfig:
 
     enable: bool = True
     refresh_days_period: Optional[int] = None
+    cache_validation_uri: str = ""
 
 
 @dataclass

--- a/menu_from_project/logic/cache_manager.py
+++ b/menu_from_project/logic/cache_manager.py
@@ -2,12 +2,18 @@
 from dataclasses import asdict
 from datetime import datetime, timedelta
 import json
+import os
 from pathlib import Path
-from typing import Optional
+import tempfile
+from typing import List, Optional
 
 # PyQGIS
-from qgis.core import QgsMessageLog
+from qgis.core import QgsMessageLog, QgsFileDownloader
 from qgis.PyQt.QtCore import QCoreApplication
+from qgis.PyQt.QtCore import (
+    QEventLoop,
+    QUrl,
+)
 
 # project
 from menu_from_project.__about__ import __title__
@@ -38,6 +44,109 @@ class CacheManager:
             f"{indent_chars}{message}", application, notifyUser=True
         )
 
+    def downloadError(self, errorMessages: List[str]):
+        """Display error messages that occurs during download
+
+        :param errorMessages: error messages
+        :type errorMessages: List[str]
+        """
+        for err in errorMessages:
+            QgsMessageLog.logMessage(
+                "Download error. " + err,
+                "Layers menu from project",
+                notifyUser=True,
+            )
+
+    def _try_load_cache_validation_file(
+        self, cache_validation_file: str, cache_validation_uri: str
+    ) -> dict:
+        """Try to load file content as json.
+
+        :param cache_validation_file: file to load
+        :type cache_validation_file: str
+        :param cache_validation_uri: cache validation uri for this file
+        :type cache_validation_uri: str
+        :return: dict from json data in file
+        :rtype: dict
+        """
+        with open(cache_validation_file, encoding="UTF-8") as f:
+            try:
+                data = json.load(f)
+                return data
+            except json.JSONDecodeError as e:
+                self.log(
+                    f"Invalid content in cache validation file '{cache_validation_uri}' : {e}. Can't check cache context."
+                )
+        return {}
+
+    def get_cache_validation(self, cache_validation_uri: str) -> dict:
+        """Read dict for cache validation for cache validation uri
+        If uri if an url with http, the file is downloaded in a temporary dir
+
+        If the file is not available (downloaded or local), an empty dict is returned
+
+        If the file content is not json, an empty dict is returned
+
+        :param cache_validation_uri: cache validation ur
+        :type cache_validation_uri: str
+        :return: dict for cache validation
+        :rtype: dict
+        """
+        data = {}
+        if cache_validation_uri.startswith("http"):
+            # download it
+            with tempfile.NamedTemporaryFile() as f:
+                temp_file_path = f.name
+
+            loop = QEventLoop()
+            project_download = QgsFileDownloader(
+                url=QUrl(cache_validation_uri),
+                outputFileName=temp_file_path,
+                delayStart=True,
+            )
+            project_download.downloadExited.connect(loop.quit)
+            project_download.downloadError.connect(self.downloadError)
+            project_download.startDownload()
+            loop.exec_()
+
+            if Path(temp_file_path).exists():
+                data = self._try_load_cache_validation_file(
+                    cache_validation_file=temp_file_path,
+                    cache_validation_uri=cache_validation_uri,
+                )
+                os.remove(temp_file_path)
+            else:
+                self.log(
+                    f"Error when downloading cache validation file '{cache_validation_uri}'. Can't check cache context."
+                )
+        else:
+            if Path(cache_validation_uri).exists():
+                data = self._try_load_cache_validation_file(
+                    cache_validation_file=cache_validation_uri,
+                    cache_validation_uri=cache_validation_uri,
+                )
+            else:
+                self.log(
+                    f"Cache validation file '{cache_validation_uri}' doesn't exist. Can't check cache context."
+                )
+        return data
+
+    def get_available_cache_info(self, project: Project) -> dict:
+        """Read available cache info, empty dict if no cache info available
+
+        :param project: project
+        :type project: Project
+        :return: cache info in dict
+        :rtype: dict
+        """
+        cache_info = {}
+        cache_path = self.get_project_cache_dir(project)
+        cache_info_path = cache_path / "cache_info.json"
+        if cache_info_path.exists():
+            with open(cache_info_path, encoding="UTF-8") as f:
+                cache_info = json.load(f)
+        return cache_info
+
     def check_if_cache_enabled(self, project: Project) -> bool:
         """Check if cache is enabled for project
 
@@ -52,16 +161,18 @@ class CacheManager:
             return False
 
         # Check if a cache info is available
-        cache_info = {}
-        cache_path = self.get_project_cache_dir(project)
-        cache_info_path = cache_path / "cache_info.json"
-        if cache_info_path.exists():
-            with open(cache_info_path, encoding="UTF-8") as f:
-                cache_info = json.load(f)
-        if "last_refresh" in cache_info and cache_config.refresh_days_period:
+        cache_info = self.get_available_cache_info(project)
+
+        # Get cache last refresh
+        if "last_refresh" in cache_info:
             cache_last_refresh = datetime.strptime(
                 cache_info["last_refresh"], self.DATETIME_FORMAT
             )
+        else:
+            cache_last_refresh = None
+
+        # Check refresh days period
+        if cache_last_refresh and cache_config.refresh_days_period:
             refresh_date = cache_last_refresh + timedelta(
                 days=cache_config.refresh_days_period
             )
@@ -72,6 +183,24 @@ class CacheManager:
                     )
                 )
                 return False
+
+        # Check validation file
+        if cache_config.cache_validation_uri:
+            cache_validation_data = self.get_cache_validation(
+                cache_config.cache_validation_uri
+            )
+            if "last_release" in cache_validation_data and cache_last_refresh:
+                last_release = datetime.strptime(
+                    cache_validation_data["last_release"], self.DATETIME_FORMAT
+                )
+                if last_release > cache_last_refresh:
+                    self.log(
+                        self.tr(
+                            f"Cache is not up to date with last release version in cache validation file {last_release} for project {project.name}."
+                        )
+                    )
+                    return False
+
         return True
 
     def get_project_menu_config(self, project: Project) -> Optional[MenuProjectConfig]:

--- a/menu_from_project/logic/custom_datatypes.py
+++ b/menu_from_project/logic/custom_datatypes.py
@@ -18,5 +18,6 @@ TABLE_COLUMNS_ORDER = namedtuple(
         "uri",
         "refresh_days",
         "enable_cache",
+        "cache_validation_file",
     ],
 )

--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -138,6 +138,7 @@ class PlgOptionsManager:
                                 "refresh_days_period", None, type=int
                             ),
                             enable=s.value("enable", True, type=bool),
+                            cache_validation_uri=s.value("cache_validation_uri", ""),
                         )
                         s.endGroup()
 
@@ -193,6 +194,10 @@ class PlgOptionsManager:
                         "refresh_days_period", project.cache_config.refresh_days_period
                     )
                     s.setValue("enable", project.cache_config.enable)
+                    s.setValue(
+                        "cache_validation_uri",
+                        project.cache_config.cache_validation_uri,
+                    )
                     s.endGroup()
             finally:
                 s.endArray()

--- a/menu_from_project/ui/conf_dialog.ui
+++ b/menu_from_project/ui/conf_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>828</width>
-    <height>310</height>
+    <width>753</width>
+    <height>336</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -98,7 +98,7 @@
         <number>1</number>
        </property>
        <property name="columnCount">
-        <number>7</number>
+        <number>8</number>
        </property>
        <attribute name="horizontalHeaderVisible">
         <bool>true</bool>
@@ -155,6 +155,11 @@
        <column>
         <property name="text">
          <string>Enable cache</string>
+        </property>
+       </column>
+       <column>
+        <property name="text">
+         <string>Cache validation file</string>
         </property>
        </column>
       </widget>

--- a/menu_from_project/ui/menu_conf_dlg.py
+++ b/menu_from_project/ui/menu_conf_dlg.py
@@ -18,7 +18,7 @@ from menu_from_project.toolbelt.preferences import (
     PlgOptionsManager,
 )
 from qgis.core import QgsApplication, Qgis, QgsMessageLog
-from qgis.gui import QgsProviderGuiRegistry, QgsSpinBox
+from qgis.gui import QgsProviderGuiRegistry, QgsSpinBox, QgsFileWidget
 from qgis.PyQt import uic
 from qgis.PyQt.QtCore import QRect, Qt
 from qgis.PyQt.QtGui import QIcon, QPixmap
@@ -41,7 +41,6 @@ from qgis.utils import iface
 from menu_from_project.__about__ import DIR_PLUGIN_ROOT, __title__, __version__
 from menu_from_project.logic.custom_datatypes import TABLE_COLUMNS_ORDER
 from menu_from_project.logic.tools import (
-    guess_type_from_uri,
     icon_per_storage_type,
 )
 
@@ -84,6 +83,7 @@ class MenuConfDialog(QDialog, FORM_CLASS):
             uri=4,
             refresh_days=5,
             enable_cache=6,
+            cache_validation_file=7,
         )
 
         # menu locations
@@ -213,6 +213,11 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         # Cache enable
         self.tableWidget.cellWidget(idx, self.cols.enable_cache).setChecked(
             project.cache_config.enable
+        )
+
+        # Cache validation file
+        self.tableWidget.cellWidget(idx, self.cols.cache_validation_file).setFilePath(
+            project.cache_config.cache_validation_uri
         )
 
     def setSourceMdText(self):
@@ -355,6 +360,9 @@ class MenuConfDialog(QDialog, FORM_CLASS):
                 row, self.cols.refresh_days
             ).value(),
             enable=self.tableWidget.cellWidget(row, self.cols.enable_cache).isChecked(),
+            cache_validation_uri=self.tableWidget.cellWidget(
+                row, self.cols.cache_validation_file
+            ).filePath(),
         )
 
         type_storage = self.tableWidget.item(row, self.cols.uri).data(Qt.UserRole)
@@ -450,6 +458,18 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         checkbox = QCheckBox()
         checkbox.setChecked(True)
         self.tableWidget.setCellWidget(row, self.cols.enable_cache, checkbox)
+
+        # Cache validation file
+        cache_validation_file_item = QTableWidgetItem()
+        cache_validation_file_item.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+        self.tableWidget.setItem(
+            row, self.cols.cache_validation_file, cache_validation_file_item
+        )
+        qgs_file_widget = QgsFileWidget()
+        qgs_file_widget.setFilter("*.json")
+        self.tableWidget.setCellWidget(
+            row, self.cols.cache_validation_file, qgs_file_widget
+        )
 
     def onAdd(self, qgs_type_storage: str = "file"):
         """Add a new line to the table.


### PR DESCRIPTION
With this PR we can disable cache use if the last refresh date is lower than a release date stored in a .json file.

This file can be located:
- locally
- in a accessible http url

## Added

- new `ProjectCacheConfig` parameter `cache_validation_uri`
- use this new parameter to get the data as dict
- check if the last refresh date is lower than a release date stored
- if there are any errors (download failed, invalid file content), we still consider the cache valid

----

- :heart: Funded by [Oslandia](https://oslandia.com/), @eptb-loire and [ANFSI](https://www.linkedin.com/company/anfsi/about/)
