### PR TITLE
update(packaging): make changelog compliant with 'keep a changelog' convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,67 @@
 # CHANGELOG
 
-## 2.0.7 - 2023/04/26
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+<!--
+
+Unreleased
+
+## [{version_tag}](https://github.com/geotribu/qtribu/releases/tag/{version_tag}) - YYYY-DD-mm
+
+-->
+
+## 2.2.0-beta1 - 2024-11-20
+
+- Layer notes as tooltip
+- Minimum QGIS version is 3.20
+
+## 2.1.0 - 2024-01-30
+
+- Support relations, fix #20
+
+## 2.1.0-beta1 - 2023-08-07
+
+- #51 Support relations
+
+## 2.0.8 - 2023-04-28
+
+- Minimum Version is 3.14
+
+## 2.0.7 - 2023-04-26
 
 - fix #77
 
-## 2.0.6
+## 2.0.6 - 2022-11-08
 
-- Added some icons (https://github.com/nicogodet)
+- Added some icons (<https://github.com/nicogodet>) #72
 
-## 2.0.5 - 2022/09/02
+## 2.0.5 - 2022-09-02
 
-- Japanese translation, thanks to Yamamoto Ryuzo (https://github.com/yamamoto-ryuzo), Tokimasasogo (https://github.com/Tokimasasogo)
+- fix #67
 
-## 2.0.0
+## 2.0.4 - 2022-09-01
+
+- Japanese translation, thanks to Yamamoto Ryuzo (<https://github.com/yamamoto-ryuzo>), Tokimasasogo (<https://github.com/Tokimasasogo>)
+
+## 2.0.3 - 2022-02-28
+
+- fix #53 Help not showing Extensions
+
+## 2.0.2 - 2021-11-26
+
+- fix #50 Alternatively use metadata as tooltip instead of OGC metadata
+
+## 2.0.1 - 2021-05-21
+
+- fix #48 (Load above in ToC), better configuration interface
+
+## 2.0.0 - 2021-05-21
 
 - Allow pointing to http/https online qgs-qgz project file,
 - Support of Joined layers
+- Minor refactoring and tooling made by @Guts, funded by Oslandia and ANFSI
 
-## 1.1.0
+## 1.1.0 - 2020-09-04
 
 - It is now possible to merge two projects (#27).
 
@@ -55,7 +99,7 @@
 - Allow a project stored in database, thanks to Etienne Trimaille (<https://github.com/Gustry>)
 - Allow qgz projects
 
-## 0.8.3
+## 0.8.3 - 2018-06-11
 
 - When create group option is checked, the original layer visibility is preserved. Thanks to Eric LAZZARETTI.
 
@@ -71,7 +115,7 @@
 
 - Migration for QGIS3
 
-## 0.7.6
+## 0.7.6 - 2016-12-29
 
 - Better documentation
 
@@ -95,18 +139,18 @@
 
 - QGIS 2.4 compatible. Deprecated functions are deleted
 
-## 0.7.0
+## 0.7.0 - 2014-06-10
 
-- with "relative path" projects, and embedded layers
+- works with "relative path" projects, and embedded layers
 
 ## 0.6.0
 
 - 2.2 compatible
 
-## 0.5.0
+## 0.5.0 - 2013-08-06
 
 - 2.0 compatible
 
-## 0.4.1
+## 0.4.1 - 2013-03-21
 
 - Load all layers item, create group option (dev version 1.9)

--- a/menu_from_project/metadata.txt
+++ b/menu_from_project/metadata.txt
@@ -8,48 +8,6 @@ about=Allow easy opening of layers maintaining their style.
 version=2.2.0-beta1
 
 changelog=
-    2.2.0-beta1 : Layer notes as tooltip. Minimum Version is 3.20
-    2.1.0 : Support relations, fix #20
-    2.1.0-beta1 : #51 Support relations
-    2.0.8 : Minimum Version is 3.14
-    2.0.7 : fix #77
-    2.0.6 : fix #72 (https://github.com/nicogodet)
-    2.0.5 : fix #67
-    2.0.4 : Japanese translation is available (https://github.com/Tokimasasogo)
-    2.0.3 : fix #53 Help not showing Extensions
-    2.0.2 : fix #50 Alternatively use metadata as tooltip instead of OGC metadata
-    2.0.1 : fix #48 (Load above in ToC), better configuration interface
-    2.0.1-beta1 : fix #48 (Load above in ToC), better configuration interface
-    2.0.0 : Allow pointing to http/https online qgs-qgz project file (#28)
-      thanks to Julien Moura (https://github.com/Guts)
-      Support of Joined layers
-    1.1.0 : It is now possible to merge two projects (#27).
-    1.0.6 : Build menus on initializationCompleted, otherwise tooltips are imperfect
-    1.0.5 : fix #25
-    1.0.4 : Add support for "trusted project" option, thanks to https://github.com/Djedouas
-    1.0.3 : fix #20 - Layer doesn't appear when sourced from "Integrate layers and group"
-    1.0.2 : Load all styles from DB if the plugin DB-Style-Manager is setup
-    1.0.1 : Bugfix #18. Relative paths mode
-    1.0.0 : Display geometry type icon, new location possible : "add layer" menu, code cleaning
-      thanks to Etienne Trimaille (https://github.com/Gustry)
-      Fix load-all failure
-    0.9.0 : Allow a project stored in database, thanks to Etienne Trimaille (https://github.com/Gustry)
-      allow qgz projects
-    0.8.3 : When create group option is checked, the original layer visibility is preserved.
-      thanks to Eric LAZZARETTI
-    0.8.2 : Code cleaning
-    0.8.1 : QGIS 2.99 compatible, Python 3, QT5
-    0.8.0 : Migration for QGIS3
-    0.7.6 : Better documentation
-    0.7.5 : Tooltip refinement
-    0.7.4 : Some python cleaning
-    0.7.3 : New layer id without special characters
-    0.7.2 : Some optimizations
-    0.7.1 : QGIS 2.4 compatible. Deprecated functions are deleted
-    0.7 : Works with "relative path" projects, and embedded layers
-    0.6 : QGIS 2.2 compatible
-    0.5 : QGIS 2.0 compatible
-    0.4.1 : Load all layers item, create group option (dev version 1.9)
 
 # tags are comma separated with spaces allowed
 tags=menu layer project


### PR DESCRIPTION
This PR cleans up the changelog to make it compliant with the https://keepachangelog.com/fr/1.1.0/ convention which is used behind the scenes by a lot of tools and especially QGIS Plugin CI, which was added to this repository back in 2021 (https://github.com/xcaeag/MenuFromProject-Qgis-Plugin/pull/47).

Here are the main advantages:

- document changes in a conventional file (CHANGELOG.md) instead of changelog section of metadata.txt
- when using QGIS Plugin CI with package or release commands, it will load the CHANGELOG.md content to extract the latest version number (or the one specified), the associated changes and write them into the metadata.txt
- Github understands and features the CHANGELOG.md
- it can be added to the online doc

----

- :heart: Funded by [Oslandia](https://oslandia.com/), @eptb-loire and [ANFSI](https://www.linkedin.com/company/anfsi/about/)