### PR TITLE
fix(settings): invalid remove use we must indicate projects

### DIFF
--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -183,7 +183,7 @@ class PlgOptionsManager:
             s.setValue("optionOpenLinks", plugin_settings_obj.optionOpenLinks)
             s.setValue("optionSourceMD", ",".join(plugin_settings_obj.optionSourceMD))
 
-            s.remove("menu_from_project", "projects")
+            s.remove("projects")
             s.beginWriteArray("projects", len(plugin_settings_obj.projects))
             try:
                 for i, project in enumerate(plugin_settings_obj.projects):


### PR DESCRIPTION
closes #138 

After some tests on Windows, there is an issue with the use of `QgsSettings::remove`. We need to indicate the name of the attribute to remove.