### PR TITLE
Update minimum QGIS version requirement to 3.34

### DIFF
--- a/menu_from_project/metadata.txt
+++ b/menu_from_project/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Layers menu from project
-qgisMinimumVersion=3.28
+qgisMinimumVersion=3.34
 qgisMaximumVersion=3.98
 description=Build layers shortcuts menus based on QGIS projects
 about=Allow easy opening of layers maintaining their style.


### PR DESCRIPTION
Rationale:

- main improvements on performance have been shipped with previous version compatible with QGIS 3.28+
- actual and future work is lead by new features
- next LTR version is scheduled for February 2025
- older QGIS versions are not supported by the community
- reduce maintenance costs