### PR TITLE
fix(browser): don't add group that start with -

### DIFF
--- a/docs/usage/en_use.md
+++ b/docs/usage/en_use.md
@@ -19,7 +19,7 @@ The project might be stored in a PostgreSQL database, or on a web server, which 
 If you want some hierarchical menu, just use groups and sub groups in layer's panel, they will be reused to build the same hierarchical menu.
 
 ```{tip}
-Create an empty group named "-" to build a separator line in dropdown menu
+Create an empty group named "-" to build a separator line in dropdown menu. This is not supported for QGIS browser.
 ```
 
 ```{note}

--- a/docs/usage/fr_use.md
+++ b/docs/usage/fr_use.md
@@ -13,7 +13,7 @@ Lorsque le plugin est configuré (choix des projets et attribution d'un nom asso
 Sauver vos projets sur un espace partagé (réseau, web, postgres) avec leurs styles, leurs étiquettes... une arborescence de groupes à l'image du futur menu.
 
 ```{tip}
-Créer un groupe vide nommé "-" pour placer un séparateur à cet endroit dans le futur menu.
+Créer un groupe vide nommé "-" pour placer un séparateur à cet endroit dans le futur menu. Ceci n'est pas supporté pour l'explorateur QGIS.
 ```
 
 Les projets peuvent être sauvés au format qgz, dans une base PostgreSQL [(cf. feature-saving-and-loading-projects-in-postgresql-database)](https://qgis.org/en/site/forusers/visualchangelog32/index.html#feature-saving-and-loading-projects-in-postgresql-database) ou déposée en tant que ressource web.

--- a/menu_from_project/ui/menu_layer_data_item_provider.py
+++ b/menu_from_project/ui/menu_layer_data_item_provider.py
@@ -176,7 +176,11 @@ class GroupItem(QgsDataCollectionItem):
         self.layer_inserted = []
         for child in self.group_config.childs:
             if isinstance(child, MenuGroupConfig):
-                children.insert(0, GroupItem(parent=self, group_config=child))
+                name = child.name
+                # If group name is - it should be a separator but it's not supported in browser
+                # If group name start with - it should be a title but it's not supported in browser
+                if name != "-" and not name.startswith("-"):
+                    children.insert(0, GroupItem(parent=self, group_config=child))
             elif isinstance(child, MenuLayerConfig):
                 self.layer_inserted.append(child)
                 children.insert(


### PR DESCRIPTION
Since we can't add separator or title in QGIS browser, group name that starts with - are discarded in QGIS browser