### PR TITLE
update(docs): add QDT helper

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,7 +26,7 @@ caption: Usage
 usage/en_use
 usage/fr_use
 how_does_it_works
-with_qdt
+usage/with_qdt
 ```
 
 ```{toctree}

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,7 @@ caption: Usage
 usage/en_use
 usage/fr_use
 how_does_it_works
+with_qdt
 ```
 
 ```{toctree}

--- a/docs/usage/with_qdt.md
+++ b/docs/usage/with_qdt.md
@@ -1,6 +1,6 @@
 # Using this plugin with QGIS Deployment Toolbelt (QDT)
 
-If you want to use this plugin with Q[GIS Deployment Toolbelt (QDT)](https://qgis-deployment.github.io/qgis-deployment-toolbelt-cli/), you can add the following snippet to your `profile.json` file, under the `plugins` attribute:
+If you want to use this plugin with [QGIS Deployment Toolbelt (QDT)](https://qgis-deployment.github.io/qgis-deployment-toolbelt-cli/), you can add the following snippet to your `profile.json` file, under the `plugins` attribute:
 
 ```json
     {

--- a/docs/usage/with_qdt.md
+++ b/docs/usage/with_qdt.md
@@ -11,3 +11,5 @@ If you want to use this plugin with Q[GIS Deployment Toolbelt (QDT)](https://qgi
       "version": "2.2.1"
     }
 ```
+
+Remember to replace the `version` attribute with the version you want to install.

--- a/docs/usage/with_qdt.md
+++ b/docs/usage/with_qdt.md
@@ -1,0 +1,13 @@
+# Using this plugin with QGIS Deployment Toolbelt (QDT)
+
+If you want to use this plugin with Q[GIS Deployment Toolbelt (QDT)](https://qgis-deployment.github.io/qgis-deployment-toolbelt-cli/), you can add the following snippet to your `profile.json` file, under the `plugins` attribute:
+
+```json
+    {
+      "name": "Layers menu from project",
+      "folder_name": "menu_from_project",
+      "official_repository": true,
+      "plugin_id": 43,
+      "version": "2.2.1"
+    }
+```


### PR DESCRIPTION
Hola @xcaeag,

As you may know, we also work on a project called [QGIS Deployment Toolbelt](https://qgis-deployment.github.io/qgis-deployment-toolbelt-cli/). Since it can be a bit painful to fill the `profile.json` file with plugins information, we add a helper to our plugins documentation to make things easier.

cc @jmkerloch 