### PR TITLE
feat(menu): always use version for layer action creation

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -388,26 +388,13 @@ class MenuFromProject:
 
         # Create action or menu for each version
         for version, format_list in layer_dict.items():
-            multiple_format = len(format_list) > 1
-            version_menu_used = version and multiple_format
-            if version_menu_used:
-                # Multiple format for this version : create a specific menu in versions menu
-                version_menu = all_version_menu.addMenu(version)
-            else:
-                # Only one format for this version : directly create action in versions menu
-                version_menu = all_version_menu
+
+            version_label = version if version else self.tr("Latest")
+            version_menu = all_version_menu.addMenu(version_label)
 
             # Create action for each format
             for layer in format_list:
-                if version_menu_used:
-                    # Multiple format for this version : we only display format
-                    action_text = layer.format
-                else:
-                    # Only one format for this version : no specific menu, we display version and format
-                    action_text = (
-                        f"{layer.version} - {layer.format}" if version else layer.format
-                    )
-                self.add_layer(layer, version_menu, group_name, action_text)
+                self.add_layer(layer, version_menu, group_name, layer.format)
 
         return first_layer
 

--- a/menu_from_project/ui/menu_layer_data_item_provider.py
+++ b/menu_from_project/ui/menu_layer_data_item_provider.py
@@ -328,27 +328,16 @@ class LayerDictItem(QgsDataItem):
 
         # Create action or menu for each version
         for version, format_list in self.layer_dict.items():
-            multiple_format = len(format_list) > 1
-            version_menu_used = version and multiple_format
-            if version_menu_used:
-                # Multiple format for this version : create a specific menu in versions menu
-                ac_version = QAction(version, parent)
-                version_menu = QMenu(version, parent)
-                ac_version.setMenu(version_menu)
+            version_label = version if version else self.tr("Latest")
+            ac_version = QAction(version_label, parent)
+            version_menu = QMenu(version_label, parent)
+            ac_version.setMenu(version_menu)
 
-                all_version_menu.addAction(ac_version)
-            else:
-                # Only one format for this version : directly create action in versions menu
-                version_menu = all_version_menu
+            all_version_menu.addAction(ac_version)
+
             for layer in format_list:
-                if version_menu_used:
-                    action_text = layer.format
-                else:
-                    action_text = (
-                        f"{layer.version} - {layer.format}" if version else layer.format
-                    )
                 ac_layer = create_add_layer_action(
-                    layer, action_text, self.group_name, parent
+                    layer, layer.format, self.group_name, parent
                 )
                 version_menu.addAction(ac_layer)
         return actions


### PR DESCRIPTION
- if no version defined, use "latest" as label
- now there is always a version menu

With these layers :

![image](https://github.com/user-attachments/assets/fe7f985b-027c-4494-ad49-dfa80b7e41bd)

We will have these menu and actions :

[Screencast from 2025-01-29 11-07-19.webm](https://github.com/user-attachments/assets/4d8ca05a-ddc8-44df-be80-9ba05311ecba)

related #135 
