### PR TITLE
feat(browser): add option to define name in browser

### DIFF
--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -49,6 +49,9 @@ class PlgSettingsStructure:
         default_factory=lambda: [SOURCE_MD_OGC, SOURCE_MD_LAYER, SOURCE_MD_NOTE]
     )
 
+    # Browser option
+    browser_name: str = "Layers from project"
+
     # Internal option
     is_setup_visible: bool = True
 
@@ -167,6 +170,8 @@ class PlgOptionsManager:
                         SOURCE_MD_OGC,
                     ]
 
+                options.browser_name = s.value("browser_name", options.browser_name)
+
                 size = s.beginReadArray("projects")
                 try:
                     for i in range(size):
@@ -227,6 +232,8 @@ class PlgOptionsManager:
             s.setValue("optionLoadAll", plugin_settings_obj.optionLoadAll)
             s.setValue("optionOpenLinks", plugin_settings_obj.optionOpenLinks)
             s.setValue("optionSourceMD", ",".join(plugin_settings_obj.optionSourceMD))
+
+            s.setValue("browser_name", plugin_settings_obj.browser_name)
 
             s.remove("projects")
             s.beginWriteArray("projects", len(plugin_settings_obj.projects))

--- a/menu_from_project/ui/conf_dialog.ui
+++ b/menu_from_project/ui/conf_dialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>805</width>
-    <height>769</height>
+    <width>1047</width>
+    <height>960</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -151,7 +151,23 @@
       <string>Global options</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="cbxLoadAll">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Load all layers item</string>
+        </property>
+        <property name="tristate">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
        <widget class="QCheckBox" name="cbxCreateGroup">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -170,7 +186,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="3">
+      <item row="4" column="0" colspan="3">
        <layout class="QHBoxLayout" name="horizontalLayout_5">
         <item>
          <widget class="QCheckBox" name="cbxShowTooltip">
@@ -301,22 +317,6 @@
        </layout>
       </item>
       <item row="2" column="0">
-       <widget class="QCheckBox" name="cbxLoadAll">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Load all layers item</string>
-        </property>
-        <property name="tristate">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
        <widget class="QCheckBox" name="cbxOpenLinks">
         <property name="toolTip">
          <string>Opens with layer, layers linked by 'relations' or joins.</string>
@@ -328,6 +328,16 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_browser_name">
+        <property name="text">
+         <string>Browser name</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="lne_browser_name"/>
       </item>
      </layout>
     </widget>

--- a/menu_from_project/ui/menu_conf_dlg.py
+++ b/menu_from_project/ui/menu_conf_dlg.py
@@ -114,6 +114,8 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         }
         self.optionSourceMD = settings.optionSourceMD
 
+        self.lne_browser_name.setText(settings.browser_name)
+
         self.projetListModel = ProjectListModel(self)
         self.projetListModel.set_project_list(settings.projects)
         self.projectTableView.setModel(self.projetListModel)
@@ -160,6 +162,8 @@ class MenuConfDialog(QDialog, FORM_CLASS):
         settings.optionOpenLinks = self.cbxOpenLinks.isChecked()
 
         settings.optionSourceMD = self.optionSourceMD
+
+        settings.browser_name = self.lne_browser_name.text()
 
         PlgOptionsManager().save_from_object(settings)
 

--- a/menu_from_project/ui/menu_layer_data_item_provider.py
+++ b/menu_from_project/ui/menu_layer_data_item_provider.py
@@ -81,7 +81,10 @@ class RootCollection(QgsDataCollectionItem):
         :param project_configs: list of project configuration
         :type project_configs: List[Tuple[Project, MenuProjectConfig]]
         """
-        QgsDataCollectionItem.__init__(self, parent, "MenuLayer", "/MenuLayer")
+        settings = PlgOptionsManager().get_plg_settings()
+        QgsDataCollectionItem.__init__(
+            self, parent, settings.browser_name, "/MenuLayer"
+        )
         # TODO : define icon
         self.project_configs = project_configs
 


### PR DESCRIPTION
Add option in settings to define name in browser:

![image](https://github.com/user-attachments/assets/403477a3-e3c7-4c88-aa1d-734a9157ec8f)

Result in browser:

![image](https://github.com/user-attachments/assets/38c6e6cf-50e1-45bf-8fca-5c22713bb372)
