### PR TITLE
feat(conf widget): transform QDialog in QgsOptionsPageWidget

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -49,8 +49,9 @@ from menu_from_project.logic.qgs_manager import (
 )
 from menu_from_project.logic.tools import icon_per_layer_type
 from menu_from_project.toolbelt.preferences import PlgOptionsManager
-from menu_from_project.ui.menu_conf_dlg import MenuConfDialog  # noqa: F4 I001
+from menu_from_project.ui.dlg_settings import MenuConfDialog
 from menu_from_project.ui.menu_layer_data_item_provider import MenuLayerProvider
+from menu_from_project.ui.wdg_settings import PlgOptionsFactory
 
 # ############################################################################
 # ########## Classes ###############
@@ -81,6 +82,8 @@ class MenuFromProject:
 
         self.iface = iface
         self.toolBar = None
+
+        self.options_factory = None
 
         self.qgs_dom_manager = QgsDomManager()
         self.menubarActions = []
@@ -433,6 +436,22 @@ class MenuFromProject:
     def initGui(self):
         settings = self.plg_settings.get_plg_settings()
         if settings.is_setup_visible:
+            # settings page within the QGIS preferences menu
+            if not self.options_factory:
+                self.options_factory = PlgOptionsFactory()
+                self.options_factory.settingsApplied.connect(self._apply_settings)
+                self.iface.registerOptionsWidgetFactory(self.options_factory)
+                # Add search path for plugin
+                help_search_paths = QgsSettings().value("help/helpSearchPath")
+                if (
+                    isinstance(help_search_paths, list)
+                    and __uri_homepage__ not in help_search_paths
+                ):
+                    help_search_paths.append(__uri_homepage__)
+                else:
+                    help_search_paths = [help_search_paths, __uri_homepage__]
+                QgsSettings().setValue("help/helpSearchPath", help_search_paths)
+
             # menu item - Main
             self.action_project_configuration = QAction(
                 QIcon(str(DIR_PLUGIN_ROOT / "resources/menu_from_project.png")),
@@ -460,7 +479,13 @@ class MenuFromProject:
                 partial(QDesktopServices.openUrl, QUrl(__uri_homepage__))
             )
 
-        self.iface.initializationCompleted.connect(self.on_initializationCompleted)
+        self.iface.initializationCompleted.connect(self._apply_settings)
+
+    def _apply_settings(self) -> None:
+        """Apply current settings"""
+
+        # Rebuild menus and browser
+        self.initMenus()
 
     def unload(self):
         menuBar = self.iface.editMenu().parentWidget()
@@ -478,6 +503,18 @@ class MenuFromProject:
 
         settings = self.plg_settings.get_plg_settings()
         if settings.is_setup_visible:
+            # -- Clean up preferences panel in QGIS settings
+            if self.options_factory:
+                self.iface.unregisterOptionsWidgetFactory(self.options_factory)
+                # pop from help path
+                help_search_paths = QgsSettings().value("help/helpSearchPath")
+                if (
+                    isinstance(help_search_paths, list)
+                    and __uri_homepage__ in help_search_paths
+                ):
+                    help_search_paths.remove(__uri_homepage__)
+                QgsSettings().setValue("help/helpSearchPath", help_search_paths)
+
             self.iface.removePluginMenu(
                 "&" + __title__, self.action_project_configuration
             )
@@ -487,7 +524,7 @@ class MenuFromProject:
             )
             self.iface.removePluginMenu(__title__, self.action_menu_help)
 
-        self.iface.initializationCompleted.disconnect(self.on_initializationCompleted)
+        self.iface.initializationCompleted.disconnect(self._apply_settings)
 
         if self.provider:
             self.registry.removeProvider(self.provider)

--- a/menu_from_project/ui/dlg_settings.py
+++ b/menu_from_project/ui/dlg_settings.py
@@ -1,0 +1,36 @@
+#! python3  # noqa: E265
+
+"""
+    Dialog for setting up the plugin.
+"""
+
+# Standard library
+
+# PyQGIS
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog
+
+# project
+from menu_from_project.__about__ import DIR_PLUGIN_ROOT
+
+# ############################################################################
+# ########## Globals ###############
+# ##################################
+
+
+# load ui
+FORM_CLASS, _ = uic.loadUiType(DIR_PLUGIN_ROOT / "ui/dlg_settings.ui")
+
+# ############################################################################
+# ########## Classes ###############
+# ##################################
+
+
+class MenuConfDialog(QDialog, FORM_CLASS):
+    def __init__(self, parent):
+        QDialog.__init__(self, parent)
+        self.setupUi(self)
+
+    def accept(self):
+        self.wdg_config.apply()
+        super().accept()

--- a/menu_from_project/ui/dlg_settings.py
+++ b/menu_from_project/ui/dlg_settings.py
@@ -8,7 +8,7 @@
 
 # PyQGIS
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QDialog
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox
 
 # project
 from menu_from_project.__about__ import DIR_PLUGIN_ROOT
@@ -30,6 +30,10 @@ class MenuConfDialog(QDialog, FORM_CLASS):
     def __init__(self, parent):
         QDialog.__init__(self, parent)
         self.setupUi(self)
+
+        self.buttonBox.button(QDialogButtonBox.Apply).clicked.connect(
+            self.wdg_config.apply
+        )
 
     def accept(self):
         self.wdg_config.apply()

--- a/menu_from_project/ui/dlg_settings.ui
+++ b/menu_from_project/ui/dlg_settings.ui
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfDialog</class>
+ <widget class="QDialog" name="ConfDialog">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>926</width>
+    <height>499</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Projects</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff>../resources/menu_from_project.png</normaloff>../resources/menu_from_project.png</iconset>
+  </property>
+  <property name="windowOpacity">
+   <double>0.980000000000000</double>
+  </property>
+  <property name="locale">
+   <locale language="English" country="UnitedStates"/>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0" columnstretch="0">
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="SettingsWidget" name="wdg_config" native="true"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SettingsWidget</class>
+   <extends>QWidget</extends>
+   <header>menu_from_project.ui.wdg_settings</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>245</x>
+     <y>300</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>313</x>
+     <y>300</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>149</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/menu_from_project/ui/dlg_settings.ui
+++ b/menu_from_project/ui/dlg_settings.ui
@@ -45,7 +45,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/menu_from_project/ui/wdg_settings.py
+++ b/menu_from_project/ui/wdg_settings.py
@@ -60,7 +60,7 @@ class SettingsWidget(FORM_CLASS, QgsOptionsPageWidget):
             self.windowTitle() + " - {} v{}".format(__title__, __version__)
         )
         self.setWindowIcon(
-            QIcon(str(DIR_PLUGIN_ROOT / "resources/gear.svg")),
+            QIcon(str(DIR_PLUGIN_ROOT / "resources/menu_from_project.png")),
         )
 
         settings = self.plg_settings.get_plg_settings()
@@ -325,7 +325,7 @@ class PlgOptionsFactory(QgsOptionsWidgetFactory):
         self.conf_widget = None
 
     def icon(self):
-        return QIcon(str(DIR_PLUGIN_ROOT / "resources/images/icon.svg"))
+        return QIcon(str(DIR_PLUGIN_ROOT / "resources/menu_from_project.png"))
 
     def createWidget(self, parent):
         widget = SettingsWidget(parent)

--- a/menu_from_project/ui/wdg_settings.ui
+++ b/menu_from_project/ui/wdg_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>677</width>
-    <height>613</height>
+    <width>659</width>
+    <height>447</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -32,7 +32,19 @@
   <property name="locale">
    <locale language="English" country="UnitedStates"/>
   </property>
-  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0,0,0" columnstretch="0,0">
+  <layout class="QGridLayout" name="gridLayout" rowstretch="1,0" columnstretch="0,0">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="grp_project">
      <property name="title">
@@ -403,5 +415,5 @@
   <tabstop>btnAdd</tabstop>
  </tabstops>
  <resources/>
-
+ <connections/>
 </ui>

--- a/menu_from_project/ui/wdg_settings.ui
+++ b/menu_from_project/ui/wdg_settings.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ConfDialog</class>
- <widget class="QDialog" name="ConfDialog">
+ <class>SettingsWidget</class>
+ <widget class="QWidget" name="SettingsWidget">
   <property name="windowModality">
    <enum>Qt::NonModal</enum>
   </property>
@@ -31,12 +31,6 @@
   </property>
   <property name="locale">
    <locale language="English" country="UnitedStates"/>
-  </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <property name="modal">
-   <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout" rowstretch="1,0,0,0,0" columnstretch="0,0">
    <item row="0" column="0" colspan="2">
@@ -395,19 +389,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -422,38 +403,5 @@
   <tabstop>btnAdd</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ConfDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>245</x>
-     <y>300</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>ConfDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>313</x>
-     <y>300</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>149</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+
 </ui>


### PR DESCRIPTION
- create `SettingsWidget` from previous dialog, inherits `QgsOptionsPageWidget : `menu_from_project/ui/menu_conf_dlg.* -> `menu_from_project/ui/wdg_settings.*`
- add signal to indicate when settings where applied
- create new `MenuConfDialog` using new widget : new file ` menu_from_project/ui/dlg_settings.ui`
- create `PlgOptionsFactory` to insert widget in QGIS help

![image](https://github.com/user-attachments/assets/1ac43822-860e-4015-9c87-fc5f68a04c96)

- settings dialog is now modal and apply button is added

![image](https://github.com/user-attachments/assets/0cf5c423-2cca-4272-b8c7-381a7a1d6df4)


