### PR TITLE
fix(settings): avoid check of project validity when using plugin settings

### DIFF
--- a/menu_from_project/toolbelt/preferences.py
+++ b/menu_from_project/toolbelt/preferences.py
@@ -110,8 +110,6 @@ class PlgOptionsManager:
 
         s = QgsSettings()
 
-        dom_manager = QgsDomManager()
-
         if s.value("menu_from_project/is_setup_visible") is None:
             # This setting does not exist. We add it by default.
             s.setValue("menu_from_project/is_setup_visible", True)
@@ -203,8 +201,8 @@ class PlgOptionsManager:
                                 id=s.value("id", str(uuid.uuid4())),
                                 enable=s.value("enable", True, type=bool),
                                 comment=s.value("comment", ""),
+                                valid=s.value("valid", True, type=bool),
                             )
-                            project.valid = dom_manager.check_if_project_valid(project)
                             options.projects.append(project)
                 finally:
                     s.endArray()
@@ -225,6 +223,7 @@ class PlgOptionsManager:
 
         :return: plugin settings value matching key
         """
+        dom_manager = QgsDomManager()
         s = QgsSettings()
 
         s.beginGroup("menu_from_project")
@@ -259,6 +258,7 @@ class PlgOptionsManager:
                         project.cache_config.cache_validation_uri,
                     )
                     s.setValue("comment", project.comment)
+                    s.setValue("valid", dom_manager.check_if_project_valid(project))
                     s.endGroup()
             finally:
                 s.endArray()


### PR DESCRIPTION
When using project saved in a postgresql database on Windows  10 / QGIS 3.34.12 the UI is freezing for a long time :
- at launch
- after plugin configuration apply

After some debugging we see that the issue is coming from many project read from database.

The project is read from database EVERY time the plugin settings are asked.

We are checking project validity when reading project settings. 

Fix : only check project validity at write and always use write value.