### PR TITLE
fix corruption of the “helpSearchPath” variable fix #217

### DIFF
--- a/menu_from_project/menu_from_project.py
+++ b/menu_from_project/menu_from_project.py
@@ -462,13 +462,12 @@ class MenuFromProject:
                 self.iface.registerOptionsWidgetFactory(self.options_factory)
                 # Add search path for plugin
                 help_search_paths = QgsSettings().value("help/helpSearchPath")
-                if (
-                    isinstance(help_search_paths, list)
-                    and __uri_homepage__ not in help_search_paths
-                ):
-                    help_search_paths.append(__uri_homepage__)
+                if isinstance(help_search_paths, list):
+                    if __uri_homepage__ not in help_search_paths:
+                        help_search_paths.append(__uri_homepage__)
                 else:
                     help_search_paths = [help_search_paths, __uri_homepage__]
+
                 QgsSettings().setValue("help/helpSearchPath", help_search_paths)
 
             # menu item - Main


### PR DESCRIPTION
une première instance de QGis s'ouvre 
- LMFP vient enrichir helpSearchPath (initGui), cette variable devient une liste

si une deuxième instance est lancée (avant unload et nettoyage), helpSearchPath devennait alors une liste de liste (code `help_search_paths = [help_search_paths, __uri_homepage__]`)

On perdait alors à jamais (!) l'aide de QGis. 

Ce mini fix corrige cela.
